### PR TITLE
🐛 fix: Add langgraph-cli dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "1.4.0"
+version = "1.4.1"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -34,34 +34,27 @@ dependencies = [
     "uvicorn==0.34.2",
     "python-multipart==0.0.20",
     "starlette==0.46.2",
-    
     # Database
     "psycopg2-binary==2.9.10",
     "SQLAlchemy==2.0.40",
-    
     # HTTP clients
     "httpx==0.28.1",
     "requests==2.32.3",
-    
     # Environment and config
     "python-dotenv==1.0.1",
     "pydantic==2.10.5",
     "pydantic_core==2.27.2",
-    
     # Data processing
     "numpy>=1.23.5,<2.0.0",
     "pandas==2.2.3",
     "python-dateutil==2.9.0.post0",
-    
     # Visualization
     "matplotlib==3.9.3",
     "seaborn==0.13.2",
-    
     # Scientific computing
     "scikit-learn>=1.3.0",
     "scipy>=1.11.0",
     "xgboost>=2.0.0",
-    
     # LangChain ecosystem
     "langchain==0.3.17",
     "langchain-openai==0.2.14",
@@ -71,19 +64,16 @@ dependencies = [
     "langchain-core>=0.3.33,<0.4.0",
     "langchain-text-splitters==0.3.4",
     "langchain-community==0.3.16",
-    
     # OpenAI
     "openai==1.59.6",
-    
     # Gradio for chat interface
     "gradio==5.9.1",
-    
     # Utility
     "PyYAML==6.0.2",
     "Jinja2==3.1.5",
-    
     # CLI utilities
     "rich",
+    "langgraph-cli>=0.4.11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 📝 Summary
Fixes the 'Failed to spawn: langgraph' error when running `uv run langgraph dev --allow-blocking`.

## 🔧 Changes
- Added `langgraph-cli>=0.4.11` to project dependencies
- Bumped version to v1.4.1 (patch release)

## 🐛 Bug Fix
The project had `langgraph` library but was missing the `langgraph-cli` package which provides the `langgraph` command-line tool.

## ✅ Testing
- Verified `langgraph-cli` is now installed in the project dependencies
- Version bumped from 1.4.0 → 1.4.1

Co-Authored-By: Warp <agent@warp.dev>