### PR TITLE
🐛 fix: Add langgraph-cli[inmem] and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "1.4.1"
+version = "1.4.2"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -58,8 +58,8 @@ dependencies = [
     # LangChain ecosystem
     "langchain==0.3.17",
     "langchain-openai==0.2.14",
-    "langgraph==0.2.62",
-    "langsmith==0.2.10",
+    "langgraph>=0.2.62",
+    "langsmith>=0.2.10",
     "langchain-experimental==0.3.4",
     "langchain-core>=0.3.33,<0.4.0",
     "langchain-text-splitters==0.3.4",
@@ -73,7 +73,7 @@ dependencies = [
     "Jinja2==3.1.5",
     # CLI utilities
     "rich",
-    "langgraph-cli>=0.4.11",
+    "langgraph-cli[inmem]>=0.4.11",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 📝 Summary
Fixes the 'Required package langgraph-api is not installed' error when running `uv run langgraph dev --allow-blocking`.

## 🔧 Changes
- Added `langgraph-cli[inmem]>=0.4.11` to enable the `langgraph dev` command
- Updated `langgraph` from `==0.2.62` to `>=0.2.62` for compatibility with langgraph-cli[inmem]
- Updated `langsmith` from `==0.2.10` to `>=0.2.10` for compatibility with newer langgraph versions
- Bumped version to v1.4.2 (patch release)

## 🐛 Bug Fix
The project had `langgraph-cli` but was missing the `[inmem]` extra which provides:
- `langgraph-api` - API server package
- `langgraph-runtime-inmem` - In-memory persistence for development

## ✅ Testing
- Verified `langgraph dev` command launches successfully
- Server starts with welcome banner and shows URLs:
  - API: http://127.0.0.1:2024
  - Studio UI: https://smith.langchain.com/studio/
  - API Docs: http://127.0.0.1:2024/docs

## 📦 Dependencies Updated
- langgraph: 0.2.62 → 0.5.0
- langsmith: 0.2.10 → 0.3.45
- langgraph-cli: 0.4.11 (now with [inmem] extra)
- Added: langgraph-api, langgraph-runtime-inmem, and related packages

Co-Authored-By: Warp <agent@warp.dev>