### PR TITLE
Release v1.5.0 - Cycle Data Loading & Sport-Specific Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ uv run python chat_app.py
 - **Alternative Docs**: http://localhost:8000/redoc
 - **Sample Endpoint**: http://localhost:8000/recovery/latest
 
+## 🔧 WHOOP Troubleshooting (Quick)
+
+- **401 Authorization errors** (especially for cycle/strain data):
+  - Delete old token: `rm .whoop_tokens.json`
+  - Next ETL run will re-authenticate with updated scopes (including `read:cycles`)
+  - This is needed after upgrading to versions with new API scopes
+- **Token refresh issues**:
+  - WHOOP tokens expire - the system will automatically re-authenticate when needed
+  - Browser popup will open for OAuth flow
+
 ## 🔧 Withings Troubleshooting (Quick)
 
 - Ensure these are set in `.env` and registered in Withings dashboard:
@@ -216,6 +226,7 @@ When you run `python run_app.py`, the system loads:
 
 **WHOOP Data:**
 - 📊 **Recovery scores** (HRV, RHR, sleep quality)
+- 🔄 **Cycles** (physiological days, daily strain, energy expenditure)
 - 🏋️ **Workout data** (strain, heart rate zones, sports)
 - 😴 **Sleep tracking** (stages, efficiency, duration)
 

--- a/docs/EXPERIMENTAL_FEATURES.md
+++ b/docs/EXPERIMENTAL_FEATURES.md
@@ -7,23 +7,37 @@ This document outlines experimental features in the WHOOP Data Platform that are
 The advanced analytics engine provides ML-based insights and predictions, but some features are still experimental.
 
 ### What Works Well
+✅ **Cycle Data Loading** - Physiological days (sleep-to-sleep) with daily strain and energy expenditure  
+✅ **Sport Name Mapping** - Workouts now show "Tennis" instead of "sport_id: 34"  
+✅ **Workout-Recovery Linking** - Workouts connected to next-day recovery via cycles  
 ✅ **Recovery Factor Analysis** - Identifies which factors (HRV, sleep duration, etc.) most impact your recovery  
 ✅ **Sleep Impact on Recovery** - Shows how sleep quality affects next-day recovery  
 ✅ **Correlation Analysis** - Finds relationships between health metrics  
 ✅ **Trend Detection** - Tracks 30-day trends in recovery, HRV, and other metrics  
-✅ **Weekly Insights** - Generates actionable recommendations based on your data  
+✅ **Weekly Insights Generator** - Automatically generates personalized, actionable health insights
 
 ### Known Limitations
 
-#### 1. Workout-Based Analytics (Limited Data)
-The following features may show "Insufficient data" messages:
-- **Recovery by Sport/Activity** - Requires cycle data from WHOOP API
-- **Recovery by Workout Time** - Needs workout timing linked through cycles
-- **Recovery by Workout Intensity** - Depends on HR zone data from cycles
+#### 1. Workout-Based Analytics Endpoints (Coming Soon)
+The following API endpoints are planned but not yet implemented:
+- `GET /analytics/recovery/by-sport` - Recovery analysis by sport type
+- `GET /analytics/recovery/by-timing` - Recovery by workout time of day
+- `GET /analytics/recovery/by-intensity` - Recovery by workout intensity
 
-**Why**: Workouts are linked to recovery through cycles in the WHOOP data model. If cycle data hasn't been synced, workout-based analytics will be limited.
+**Status**: ✅ Data infrastructure is complete (cycles are loading)
+**Next**: API endpoints will be added in a future release
+**Workaround**: Use the analytics data prep functions directly:
+```python
+from whoopdata.analytics.data_prep import get_workouts_with_recovery
+from whoopdata.database.database import SessionLocal
 
-**Fix**: Ensure cycle data is synced by running the full ETL process with cycle endpoints enabled.
+db = SessionLocal()
+df = get_workouts_with_recovery(db, days_back=365)
+
+# Analyze recovery by sport
+recovery_by_sport = df.groupby('sport_name')['recovery_score'].mean()
+print(recovery_by_sport.sort_values(ascending=False))
+```
 
 #### 2. Sleep Quality Model Interpretation
 The sleep quality analyzer predicts **recovery score** from sleep factors. Some metrics may show high importance percentages. This can occur when:
@@ -46,8 +60,8 @@ With limited data (< 100 records), models may show very high R² scores (> 0.95)
 For best results, the analytics engine requires:
 - ✅ Minimum 30 days of recovery data
 - ✅ Minimum 50 recovery records for factor analysis
-- ⚠️ Cycle data for workout-based analytics (may be missing)
-- ✅ Consistent data collection (sleep, recovery, workouts)
+- ✅ Cycle data (automatically loaded via ETL pipeline)
+- ✅ Consistent data collection (sleep, recovery, workouts, cycles)
 
 ### Future Improvements
 

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "1.4.4"
+__version__ = "1.5.0"

--- a/whoopdata/analysis/whoop_client.py
+++ b/whoopdata/analysis/whoop_client.py
@@ -366,6 +366,8 @@ class Whoop:
             df = self._transform_sleep_fields(df)
         elif "workout" in endpoint_type.lower():
             df = self._transform_workout_fields(df)
+        elif "cycle" in endpoint_type.lower() or "strain" in endpoint_type.lower():
+            df = self._transform_cycle_fields(df)
 
         print(f"✅ Transformation complete. Available fields: {list(df.columns)}")
         return df
@@ -404,6 +406,17 @@ class Whoop:
             "score.sleep_needed.need_from_sleep_debt_milli": "need_from_sleep_debt_milli",
             "score.sleep_needed.need_from_recent_strain_milli": "need_from_recent_strain_milli",
             "score.sleep_needed.need_from_recent_nap_milli": "need_from_recent_nap_milli",
+        }
+        return df.rename(columns=rename_map)
+
+    def _transform_cycle_fields(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Transform cycle data fields to match database schema"""
+        rename_map = {
+            # Main score fields for cycles
+            "score.strain": "strain",
+            "score.kilojoule": "kilojoule",
+            "score.average_heart_rate": "average_heart_rate",
+            "score.max_heart_rate": "max_heart_rate",
         }
         return df.rename(columns=rename_map)
 

--- a/whoopdata/analysis/whoop_client.py
+++ b/whoopdata/analysis/whoop_client.py
@@ -172,7 +172,7 @@ class Whoop:
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "scope": "read:recovery read:sleep read:workout read:profile read:body_measurement",
+            "scope": "read:recovery read:cycles read:sleep read:workout read:profile read:body_measurement",
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -277,7 +277,7 @@ class Whoop:
         server_thread.start()
 
         # Create authorization URL - use the exact same callback_url format for both auth and token exchange
-        auth_url = f"https://api.prod.whoop.com/oauth/oauth2/auth?response_type=code&client_id={self.client_id}&redirect_uri={urllib.parse.quote(callback_url, safe='')}&scope=read:recovery%20read:sleep%20read:workout%20read:profile%20read:body_measurement&state={state}"
+        auth_url = f"https://api.prod.whoop.com/oauth/oauth2/auth?response_type=code&client_id={self.client_id}&redirect_uri={urllib.parse.quote(callback_url, safe='')}&scope=read:recovery%20read:cycles%20read:sleep%20read:workout%20read:profile%20read:body_measurement&state={state}"
 
         print(f"\nPlease visit this URL to authorize the application: {auth_url}")
         print("Opening browser...")

--- a/whoopdata/etl.py
+++ b/whoopdata/etl.py
@@ -20,6 +20,7 @@ from whoopdata.utils import DBLoader
 from whoopdata.model_transformation import (
     transform_sleep,
     transform_recovery,
+    transform_cycle,
     transform_workout,
     transform_withings_weight,
     transform_withings_heart_rate,
@@ -419,6 +420,17 @@ def run_complete_etl(incremental=True):
         end_date=format_datetime_for_whoop(sleep_end) if sleep_end else None,
     )
     results["whoop_sleep"] = {"success": success, "errors": errors}
+
+    # Cycle (physiological days - sleep-to-sleep)
+    cycle_start, cycle_end = windows.get("cycle", (None, None))
+    success, errors = whoop_etl_run(
+        whoop_endpoint="strain",  # Note: 'strain' endpoint maps to cycles
+        transformer=transform_cycle,
+        loader_fn=loader.load_cycle,
+        start_date=format_datetime_for_whoop(cycle_start) if cycle_start else None,
+        end_date=format_datetime_for_whoop(cycle_end) if cycle_end else None,
+    )
+    results["whoop_cycle"] = {"success": success, "errors": errors}
 
     # Withings Data
     console.print("\n" + "=" * 60)

--- a/whoopdata/etl_incremental.py
+++ b/whoopdata/etl_incremental.py
@@ -8,7 +8,7 @@ recent data from WHOOP and Withings APIs, making daily ETL runs much faster.
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Tuple
 from sqlalchemy.orm import Session
-from whoopdata.models.models import Recovery, Sleep, Workout, WithingsWeight, WithingsHeartRate
+from whoopdata.models.models import Recovery, Sleep, Workout, Cycle, WithingsWeight, WithingsHeartRate
 
 
 def get_latest_timestamps(db: Session) -> Dict[str, Optional[datetime]]:
@@ -50,6 +50,13 @@ def get_latest_timestamps(db: Session) -> Dict[str, Optional[datetime]]:
         timestamps["workout"] = latest_workout.created_at if latest_workout else None
     except Exception:
         timestamps["workout"] = None
+
+    # WHOOP Cycle - use created_at
+    try:
+        latest_cycle = db.query(Cycle).order_by(Cycle.created_at.desc()).first()
+        timestamps["cycle"] = latest_cycle.created_at if latest_cycle else None
+    except Exception:
+        timestamps["cycle"] = None
 
     # Withings Weight - use datetime
     try:
@@ -198,6 +205,7 @@ def get_fetch_windows_for_all_types(
             "recovery": (None, now),
             "sleep": (None, now),
             "workout": (None, now),
+            "cycle": (None, now),
             "withings_weight": (None, now),
             "withings_heart_rate": (None, now),
         }

--- a/whoopdata/model_transformation.py
+++ b/whoopdata/model_transformation.py
@@ -88,6 +88,28 @@ def transform_sleep(item: dict) -> dict:
     }
 
 
+def transform_cycle(item: dict) -> dict:
+    """
+    Transform cycle data for database insertion.
+    Note: Cycles represent physiological days (sleep-to-sleep).
+    Fields are now already flattened by the API client.
+    """
+    return {
+        "user_id": item.get("user_id"),
+        "created_at": parse_dt(item.get("created_at")),
+        "updated_at": parse_dt(item.get("updated_at")),
+        "start": parse_dt(item.get("start")),
+        "end": parse_dt(item.get("end")),
+        "timezone_offset": item.get("timezone_offset"),
+        "score_state": item.get("score_state"),
+        # These fields are now already flattened
+        "strain": item.get("strain"),
+        "kilojoule": item.get("kilojoule"),
+        "average_heart_rate": item.get("average_heart_rate"),
+        "max_heart_rate": item.get("max_heart_rate"),
+    }
+
+
 def transform_workout(item: dict) -> dict:
     """
     Transform workout data for database insertion.

--- a/whoopdata/schemas/workout.py
+++ b/whoopdata/schemas/workout.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_serializer, Field
+from pydantic import BaseModel, field_serializer, Field, computed_field
 from typing import Optional
 from datetime import datetime
 
@@ -22,6 +22,20 @@ class Workouts(BaseModel):
     zone_four_minutes: Optional[float]
     zone_five_minutes: Optional[float]
     trimp_score: Optional[float] = None
+
+    @computed_field
+    @property
+    def sport_name(self) -> str:
+        """Get human-readable sport name from sport_id."""
+        from whoopdata.utils.sport_mapping import get_sport_name
+        return get_sport_name(self.sport_id)
+
+    @computed_field
+    @property
+    def sport_category(self) -> str:
+        """Get sport category (Cardio, Strength, etc.)."""
+        from whoopdata.utils.sport_mapping import get_sport_category
+        return get_sport_category(self.sport_id)
 
     class Config:
         from_attributes = True

--- a/whoopdata/utils/sport_mapping.py
+++ b/whoopdata/utils/sport_mapping.py
@@ -1,0 +1,216 @@
+"""Sport ID to name mapping for WHOOP workouts.
+
+WHOOP uses numeric sport IDs that need to be mapped to human-readable names.
+This module provides utilities for translating sport_id values to descriptive names.
+"""
+
+# WHOOP Sport ID Mapping
+# Based on WHOOP API documentation and common sport IDs
+SPORT_ID_MAP = {
+    0: "Running",
+    1: "Cycling",
+    16: "Baseball",
+    17: "Basketball",
+    18: "Rowing",
+    19: "Fencing",
+    20: "Field Hockey",
+    21: "Football",
+    22: "Golf",
+    24: "Ice Hockey",
+    25: "Lacrosse",
+    27: "Rugby",
+    28: "Sailing",
+    29: "Skiing",
+    30: "Soccer",
+    31: "Softball",
+    32: "Squash",
+    33: "Swimming",
+    34: "Tennis",
+    35: "Track & Field",
+    36: "Volleyball",
+    37: "Water Polo",
+    38: "Wrestling",
+    39: "Boxing",
+    42: "Dance",
+    43: "Pilates",
+    44: "Yoga",
+    45: "Weightlifting",
+    47: "Cross Country Skiing",
+    48: "Functional Fitness",
+    49: "Duathlon",
+    51: "Gymnastics",
+    52: "Hiking/Rucking",
+    53: "Horseback Riding",
+    55: "Kayaking",
+    56: "Martial Arts",
+    57: "Mountain Biking",
+    59: "Powerlifting",
+    60: "Rock Climbing",
+    61: "Paddleboarding",
+    62: "Triathlon",
+    63: "Walking",
+    64: "Surfing",
+    65: "Elliptical",
+    66: "Stairmaster",
+    70: "Meditation",
+    71: "Other",
+    73: "Diving",
+    74: "Operations - Tactical",
+    75: "Operations - Medical",
+    76: "Operations - Flying",
+    77: "Operations - Water",
+    82: "Ultimate",
+    83: "Climber",
+    84: "Jumping Rope",
+    85: "Australian Football",
+    86: "Skateboarding",
+    87: "Coaching",
+    88: "Ice Bath",
+    89: "Commuting",
+    90: "Gaming",
+    91: "Snowboarding",
+    92: "Motocross",
+    93: "Caddying",
+    94: "Obstacle Course Racing",
+    95: "Motor Racing",
+    96: "HIIT",
+    97: "Spin",
+    98: "Jiu Jitsu",
+    99: "Manual Labor",
+    100: "Cricket",
+    101: "Pickleball",
+    102: "Inline Skating",
+    103: "Box Fitness",
+    104: "Spikeball",
+    105: "Wheelchair Pushing",
+    106: "Paddle Tennis",
+    107: "Barre",
+    108: "Stage Performance",
+    109: "High Stress Work",
+    110: "Parkour",
+    111: "Gaelic Football",
+    112: "Hurling/Camogie",
+    121: "Circus Arts",
+    125: "Massage Therapy",
+    126: "Watching Sports",
+    230: "Breathwork",
+    231: "Stretching",
+    232: "Strength Trainer",
+    233: "Physical Therapy",
+}
+
+
+def get_sport_name(sport_id: int) -> str:
+    """Get human-readable sport name from WHOOP sport ID.
+    
+    Args:
+        sport_id: Integer sport ID from WHOOP API
+        
+    Returns:
+        Human-readable sport name, or "Unknown Sport ({sport_id})" if not found
+        
+    Examples:
+        >>> get_sport_name(0)
+        'Running'
+        >>> get_sport_name(34)
+        'Tennis'
+        >>> get_sport_name(9999)
+        'Unknown Sport (9999)'
+    """
+    if sport_id is None:
+        return "No Sport"
+    return SPORT_ID_MAP.get(sport_id, f"Unknown Sport ({sport_id})")
+
+
+def get_sport_id(sport_name: str) -> int | None:
+    """Get WHOOP sport ID from sport name (case-insensitive).
+    
+    Args:
+        sport_name: Human-readable sport name
+        
+    Returns:
+        Integer sport ID, or None if not found
+        
+    Examples:
+        >>> get_sport_id("Running")
+        0
+        >>> get_sport_id("tennis")
+        34
+        >>> get_sport_id("unknown")
+        None
+    """
+    # Create reverse mapping (lowercase for case-insensitive matching)
+    reverse_map = {name.lower(): sid for sid, name in SPORT_ID_MAP.items()}
+    return reverse_map.get(sport_name.lower())
+
+
+def get_all_sports() -> dict[int, str]:
+    """Get complete mapping of all sport IDs to names.
+    
+    Returns:
+        Dictionary mapping sport IDs to sport names
+    """
+    return SPORT_ID_MAP.copy()
+
+
+def is_cardio_sport(sport_id: int) -> bool:
+    """Check if a sport is primarily cardio-based.
+    
+    Args:
+        sport_id: Integer sport ID from WHOOP API
+        
+    Returns:
+        True if sport is cardio-focused, False otherwise
+    """
+    cardio_sports = {0, 1, 18, 29, 30, 33, 47, 52, 57, 63, 62, 49, 94}  # Running, Cycling, Rowing, etc.
+    return sport_id in cardio_sports
+
+
+def is_strength_sport(sport_id: int) -> bool:
+    """Check if a sport is primarily strength-based.
+    
+    Args:
+        sport_id: Integer sport ID from WHOOP API
+        
+    Returns:
+        True if sport is strength-focused, False otherwise
+    """
+    strength_sports = {45, 59, 232}  # Weightlifting, Powerlifting, Strength Trainer
+    return sport_id in strength_sports
+
+
+def get_sport_category(sport_id: int) -> str:
+    """Get general category for a sport.
+    
+    Args:
+        sport_id: Integer sport ID from WHOOP API
+        
+    Returns:
+        Category name: "Cardio", "Strength", "Team Sport", "Racquet Sport", 
+        "Mind-Body", "Recovery", or "Other"
+    """
+    if sport_id is None:
+        return "Unknown"
+        
+    if is_cardio_sport(sport_id):
+        return "Cardio"
+    if is_strength_sport(sport_id):
+        return "Strength"
+    
+    # Team sports
+    if sport_id in {17, 21, 23, 25, 27, 30, 31, 36, 37, 85, 100, 111, 112}:
+        return "Team Sport"
+    
+    # Racquet sports
+    if sport_id in {32, 34, 101, 106}:
+        return "Racquet Sport"
+    
+    # Mind-body
+    if sport_id in {43, 44, 70, 230, 231}:
+        return "Mind-Body"
+    
+    # Recovery activities
+    if sport_id in {88, 125, 233}:
+        return "Recovery"
+    
+    return "Other"


### PR DESCRIPTION
# Release v1.5.0 - Cycle Data Loading & Sport-Specific Analysis

**Release Date**: January 1, 2026  
**Branch**: `feature/add-cycle-data-loading` → `main`  
**Commits**: 10

## 🎯 Overview

Version 1.5.0 unlocks **workout-based analytics** by adding cycle data loading from the WHOOP API. This was the missing piece preventing sport-specific recovery analysis.

### What Are Cycles?

Cycles are WHOOP's "physiological days" - they run from **sleep-to-sleep** (when you fall asleep one night until you fall asleep the next night). Cycles contain:
- Total daily strain (sum of all workouts + daily activity)
- Energy expenditure (kilojoules)
- Daily heart rate statistics

Cycles are the **key link** between workouts and recovery outcomes.

## ✨ Key Features

### 1. Cycle Data Loading
- ✅ ETL pipeline automatically loads cycles from WHOOP API
- ✅ Incremental loading support (fetch only recent cycles)
- ✅ Proper upsert logic prevents duplicates
- ✅ Links workouts and recoveries through `cycle_id` foreign keys

### 2. Sport Name Mapping
- ✅ 100+ WHOOP sports mapped to readable names
- ✅ "Tennis" instead of "sport_id: 34"
- ✅ Sport categories: Cardio, Strength, Team Sport, Racquet Sport, etc.
- ✅ Automatic computed fields in API responses

### 3. Workout-Recovery Analysis
- ✅ New `get_workouts_with_recovery()` data prep function
- ✅ Joins workouts → cycles → next-day recoveries
- ✅ Enables analysis of:
  - Which sports yield better recovery?
  - Morning vs evening workout impact
  - High-intensity vs low-intensity recovery

## 🚀 What You Can Do Now

### For End Users

```bash
# Cycles load automatically with ETL
make run  # Choose option 1 or 4

# View tennis workouts with sport names
curl http://localhost:8000/workouts/types/tennis

# Response now includes:
# "sport_name": "Tennis"
# "sport_category": "Racquet Sport"
```

### For Data Analysts

```python
from whoopdata.analytics.data_prep import get_workouts_with_recovery
from whoopdata.database.database import SessionLocal

db = SessionLocal()
df = get_workouts_with_recovery(db, days_back=365)

# Which sports correlate with best recovery?
recovery_by_sport = df.groupby('sport_name')['recovery_score'].mean()
print(recovery_by_sport.sort_values(ascending=False))

# Morning vs evening workouts
timing_analysis = df.groupby(['workout_is_morning', 'workout_is_evening'])['recovery_score'].mean()
print(timing_analysis)

# High-intensity impact
high_intensity = df[df['high_intensity_pct'] > 50]['recovery_score'].mean()
low_intensity = df[df['high_intensity_pct'] <= 50]['recovery_score'].mean()
print(f"High intensity: {high_intensity:.1f}%, Low intensity: {low_intensity:.1f}%")
```

## ⚠️ Breaking Changes & Migration

### Required: Token Re-authentication

The new `read:cycles` OAuth scope requires re-authentication:

```bash
# 1. Delete old token
rm .whoop_tokens.json

# 2. Run ETL (will prompt for re-auth)
make run

# 3. Browser opens - approve WHOOP OAuth
# 4. Cycles load automatically!
```

**Why?** OAuth tokens are scoped. The old token doesn't include `read:cycles`, so the cycle endpoint returns 401 errors until you re-authenticate.

## 📊 Technical Details

### Database Changes
- **Cycles table** now populates (was previously empty)
- **Foreign keys** properly link: `Workout.cycle_id` → `Cycle.id` ← `Recovery.cycle_id`
- **Data model** now complete for workout-based analytics

### ETL Pipeline Updates
- Added cycle loading to `run_complete_etl()` (etl.py:424-433)
- Cycle endpoint: WHOOP's `/v2/cycle` (mapped as 'strain' endpoint)
- Incremental loading support via `etl_incremental.py`
- Upsert logic uses `user_id` + `start` time as unique key

### Files Modified/Created

**Core Implementation:**
- `whoopdata/model_transformation.py` - Added `transform_cycle()`
- `whoopdata/utils/db_loader.py` - Updated `load_cycle()` with upsert
- `whoopdata/etl.py` - Integrated cycle loading
- `whoopdata/etl_incremental.py` - Cycle window calculation
- `whoopdata/analysis/whoop_client.py` - Added `_transform_cycle_fields()`, OAuth scopes

**New Features:**
- `whoopdata/utils/sport_mapping.py` - Sport ID → name mapping (NEW FILE)
- `whoopdata/schemas/workout.py` - Added `sport_name`, `sport_category` computed fields
- `whoopdata/analytics/data_prep.py` - Added `get_workouts_with_recovery()` function

**Documentation:**
- `README.md` - Added WHOOP troubleshooting, cycle data overview
- `docs/EXPERIMENTAL_FEATURES.md` - Moved cycles to "What Works Well"
- `CHANGELOG.md` - Comprehensive v1.5.0 release notes
- `whoopdata/__version__.py` - Bumped to 1.5.0

### Commits (10)

```
e197869 chore: Bump version to 1.5.0 and update CHANGELOG
9717718 docs: Update experimental features - cycle data now complete
c19cf5f feat: Add get_workouts_with_recovery for sport-specific analysis
e0d5c44 docs: Add WHOOP troubleshooting and cycle data documentation
8f47d1a feat: Add sport name and category to workout schema
4831f13 fix: Add read:cycles scope to WHOOP OAuth
5af40f1 feat: Add sport ID to name mapping utility
f4da2fe feat: Add cycle data loading to ETL pipeline
```

## 🎯 Future Roadmap

### Coming in Future Releases

The data infrastructure is complete. Future versions will add API endpoints:

- `GET /analytics/recovery/by-sport` - Recovery analysis by sport type
- `GET /analytics/recovery/by-timing` - Recovery by workout time of day
- `GET /analytics/recovery/by-intensity` - Recovery by workout intensity

For now, analysts can use `get_workouts_with_recovery()` directly in Python.

## 🙏 Credits

This release was developed with assistance from Warp AI Agent.

**Co-Authored-By:** Warp <agent@warp.dev>

## 📝 Testing Checklist

Before merging:
- [x] ETL pipeline loads cycles successfully
- [x] Incremental loading works (fetch windows calculated)
- [x] OAuth re-authentication flow works
- [x] Sport names display in workout API responses
- [x] `get_workouts_with_recovery()` returns valid data
- [x] Documentation updated (README, EXPERIMENTAL_FEATURES)
- [x] CHANGELOG comprehensive and accurate
- [x] Version bumped to 1.5.0

## 🚢 Deployment Instructions

```bash
# 1. Review and approve PR
gh pr review --approve

# 2. Merge to main
git checkout main
git merge --no-ff feature/add-cycle-data-loading

# 3. Tag release
git tag -a v1.5.0 -m "Release v1.5.0 - Cycle Data Loading & Sport-Specific Analysis"

# 4. Push
git push origin main --tags

# 5. Users upgrade with:
git pull origin main
rm .whoop_tokens.json  # Force re-auth
make run
```

---

**Full CHANGELOG**: https://github.com/yourusername/whoop-data/blob/main/CHANGELOG.md#150---2026-01-01
