### PR TITLE
Upgrade WHOOP integration to v2 and restore green tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is a personal health intelligence system that consolidates data fro
 - **Chat Agent** -- LangGraph-based agent for natural language queries against your health data
 - **Dashboard** -- Web UI with charts, MLR coefficient tables, partial correlation charts, and correlation heatmaps
 
-## How it works
+## Public Surface Model
 
 - **`data`** -- Raw health records, context resources, and provider status under `/api/v1/data/*`
 - **`insights`** -- Derived dashboards, analytics, scenarios, plans, and reports under `/api/v1/insights/*`
@@ -25,6 +25,8 @@ This project is a personal health intelligence system that consolidates data fro
 - **`web`** -- Human-facing pages at `/dashboard`, `/analytics`, and `/report`
 
 New integrations should target the canonical namespaces above. Legacy aliases still exist in a few places as temporary compatibility adapters during the migration.
+
+WHOOP developer integrations in this repository target the WHOOP **v2** API. The app's own route versioning under `/api/v1/*` is internal product/API namespacing and is separate from the upstream WHOOP developer API version.
 
 ## Quick Start
 
@@ -56,7 +58,7 @@ WITHINGS_CALLBACK_URL=http://localhost:8766/callback
 OPENAI_API_KEY=your_openai_api_key
 ```
 
-WHOOP uses OAuth 2.0 browser authentication -- you will be redirected to log in through their website when first running the ETL.
+WHOOP uses OAuth 2.0 browser authentication -- you will be redirected to log in through their website when first running the ETL. Some WHOOP developer apps do not allow the `client_credentials` grant; in that case the local clients in this repo fall back to the browser-based authorization-code flow.
 ### 3. Ingest Data
 
 ```bash

--- a/custom_gpt/authenticate.yaml
+++ b/custom_gpt/authenticate.yaml
@@ -4,10 +4,10 @@ info:
   description: Authenticate with the Whoop API to obtain an access token.
   version: 1.0.0
 servers:
-  - url: https://api-7.whoop.com
+  - url: https://api.prod.whoop.com
     description: Authentication server
 paths:
-  /oauth/token:
+  /oauth/oauth2/token:
     post:
       operationId: authenticate
       summary: Authenticate with the Whoop API

--- a/custom_gpt/get_workout.yaml
+++ b/custom_gpt/get_workout.yaml
@@ -7,7 +7,7 @@ servers:
   - url: https://api.prod.whoop.com
     description: Whoop data server
 paths:
-  /v1/activity/workout:
+  /v2/activity/workout:
     get:
       operationId: getWorkoutCollection
       summary: Get a collection of workouts for a user
@@ -53,8 +53,9 @@ paths:
                       type: object
                       properties:
                         id:
-                          type: integer
-                          description: Unique ID of the workout.
+                          type: string
+                          format: uuid
+                          description: Unique UUID of the workout.
                         user_id:
                           type: integer
                           description: User ID.

--- a/tests/test_protein_tool.py
+++ b/tests/test_protein_tool.py
@@ -1,45 +1,37 @@
-"""Test script for protein recommendation tool."""
+"""Tests for protein recommendation tool."""
 
-import asyncio
-from whoopdata.agent.tools import get_protein_recommendation_tool, get_weight_data_tool
+from __future__ import annotations
 
+import pytest
 
-async def test_protein_recommendation():
-    """Test the protein recommendation tool."""
-    
-    print("=" * 60)
-    print("Testing Protein Recommendation Tool")
-    print("=" * 60)
-    
-    # Test 1: Check weight data availability
-    print("\n1. Testing weight data retrieval...")
-    weight_result = await get_weight_data_tool(latest=True)
-    print(f"Weight data result (first 200 chars):\n{weight_result[:200]}...")
-    
-    # Test 2: Normal activity level
-    print("\n2. Testing protein recommendation - Normal activity...")
-    result_normal = await get_protein_recommendation_tool(activity_level="normal")
-    print(f"Result: {result_normal}")
-    
-    # Test 3: Endurance training
-    print("\n3. Testing protein recommendation - Endurance training...")
-    result_endurance = await get_protein_recommendation_tool(activity_level="endurance training")
-    print(f"Result: {result_endurance}")
-    
-    # Test 4: Resistance training
-    print("\n4. Testing protein recommendation - Resistance training...")
-    result_resistance = await get_protein_recommendation_tool(activity_level="resistance/strength training")
-    print(f"Result: {result_resistance}")
-    
-    # Test 5: Invalid activity level
-    print("\n5. Testing protein recommendation - Invalid activity level...")
-    result_invalid = await get_protein_recommendation_tool(activity_level="invalid")
-    print(f"Result: {result_invalid}")
-    
-    print("\n" + "=" * 60)
-    print("Testing Complete!")
-    print("=" * 60)
+from whoopdata.agent import tools as agent_tools
 
 
-if __name__ == "__main__":
-    asyncio.run(test_protein_recommendation())
+@pytest.mark.anyio
+async def test_protein_recommendation(monkeypatch: pytest.MonkeyPatch):
+    """Protein recommendations should be derived from latest weight and activity level."""
+
+    class FakeWeightTool:
+        async def ainvoke(self, _args):
+            return '{"weight_kg": 70.0}'
+
+    monkeypatch.setattr(agent_tools, "get_weight_data_tool", FakeWeightTool())
+
+    result_normal = await agent_tools.get_protein_recommendation_tool.coroutine(
+        activity_level="normal"
+    )
+    result_endurance = await agent_tools.get_protein_recommendation_tool.coroutine(
+        activity_level="endurance training"
+    )
+    result_resistance = await agent_tools.get_protein_recommendation_tool.coroutine(
+        activity_level="resistance/strength training"
+    )
+    result_invalid = await agent_tools.get_protein_recommendation_tool.coroutine(
+        activity_level="invalid"
+    )
+
+    assert "70.0kg" in result_normal
+    assert "84g - 98g protein per day" in result_normal
+    assert "84g - 98g protein per day" in result_endurance
+    assert "112g - 154g protein per day" in result_resistance
+    assert "Invalid activity level" in result_invalid

--- a/tests/test_whoop_v2_migration.py
+++ b/tests/test_whoop_v2_migration.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+import inspect
+
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from whoopdata.analysis.whoop_client import Whoop as AnalysisWhoop
+from whoopdata.analysis.whoop_client_fast import WhoopFast
+from whoopdata.analysis.whoop_client_nodes import WhoopNodes
+from whoopdata.analysis.whoop_simple import WhoopSimple
+from whoopdata.clients.whoop_client import Whoop as LegacyWhoop
+from whoopdata.model_transformation import transform_sleep, transform_workout
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_all_maintained_whoop_clients_use_v2_endpoints():
+    client_classes = [AnalysisWhoop, WhoopFast, WhoopNodes, LegacyWhoop]
+
+    for client_cls in client_classes:
+        for endpoint in client_cls.ENDPOINTS.values():
+            assert "/developer/v2/" in endpoint
+            assert "/developer/v1/" not in endpoint
+
+    whoop_simple_source = inspect.getsource(WhoopSimple)
+    assert "/developer/v2/" in whoop_simple_source
+    assert "/developer/v1/" not in whoop_simple_source
+
+
+def test_legacy_client_maps_v2_zone_durations_fields():
+    client = LegacyWhoop(client_id="x", client_secret="y")
+    df = pd.DataFrame(
+        [
+            {
+                "score.zone_durations.zone_zero_milli": 60000,
+                "score.zone_durations.zone_one_milli": 120000,
+                "score.zone_durations.zone_two_milli": 180000,
+                "score.zone_durations.zone_three_milli": 240000,
+                "score.zone_durations.zone_four_milli": 300000,
+                "score.zone_durations.zone_five_milli": 360000,
+            }
+        ]
+    )
+
+    transformed = client._transform_workout_fields(df)
+
+    assert transformed.loc[0, "zone_zero_minutes"] == 1.0
+    assert transformed.loc[0, "zone_one_minutes"] == 2.0
+    assert transformed.loc[0, "zone_two_minutes"] == 3.0
+    assert transformed.loc[0, "zone_three_minutes"] == 4.0
+    assert transformed.loc[0, "zone_four_minutes"] == 5.0
+    assert transformed.loc[0, "zone_five_minutes"] == 6.0
+
+
+def test_transform_sleep_handles_v2_uuid_ids():
+    item = {
+        "id": "ecfc6a15-4661-442f-a9a4-f160dd7afae8",
+        "user_id": "user-1",
+        "created_at": "2026-03-20T10:00:00Z",
+        "updated_at": "2026-03-20T10:05:00Z",
+        "start": "2026-03-19T22:00:00Z",
+        "end": "2026-03-20T06:00:00Z",
+    }
+
+    transformed = transform_sleep(item)
+
+    assert transformed["whoop_id"] == item["id"]
+
+
+def test_transform_workout_handles_v2_uuid_ids():
+    item = {
+        "id": "7bfc6a15-5521-612f-b9a4-e274dd7afae9",
+        "user_id": "user-1",
+        "created_at": "2026-03-20T10:00:00Z",
+        "updated_at": "2026-03-20T10:05:00Z",
+        "start": "2026-03-20T07:00:00Z",
+        "end": "2026-03-20T08:00:00Z",
+    }
+
+    transformed = transform_workout(item)
+
+    assert transformed["whoop_id"] == item["id"]
+
+
+def test_custom_gpt_workout_spec_uses_v2_and_uuid_ids():
+    spec_path = ROOT / "custom_gpt" / "get_workout.yaml"
+    spec = yaml.safe_load(spec_path.read_text())
+
+    assert "/v2/activity/workout" in spec["paths"]
+    workout_schema = spec["paths"]["/v2/activity/workout"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["records"]["items"]["properties"]["id"]
+    assert workout_schema["type"] == "string"
+    assert workout_schema["format"] == "uuid"

--- a/whoopdata/analysis/sleep_scoring.py
+++ b/whoopdata/analysis/sleep_scoring.py
@@ -37,8 +37,8 @@ password = os.getenv("PASSWORD")
 access_token = whoop_authentication(username=username, password=password)
 headers = {"Authorization": f"Bearer {access_token}"}
 # API Endpoints
-url_sleep = f"https://api.prod.whoop.com/developer/v1/activity/sleep/"
-url_recovery = f"https://api.prod.whoop.com/developer/v1/recovery/"
+url_sleep = f"https://api.prod.whoop.com/developer/v2/activity/sleep/"
+url_recovery = f"https://api.prod.whoop.com/developer/v2/recovery/"
 
 
 # Get recovery data

--- a/whoopdata/analysis/test.py
+++ b/whoopdata/analysis/test.py
@@ -15,7 +15,7 @@ sleep_url = whoop.get_endpoint_url("sleep")
 
 
 stg_recovery = whoop.make_paginated_request(recovery_url)
-stg_sleep = whoop.make_paginated_request("https://api.prod.whoop.com/developer/v1/activity/sleep/")
+stg_sleep = whoop.make_paginated_request("https://api.prod.whoop.com/developer/v2/activity/sleep/")
 
 
 stg_sleep.info()

--- a/whoopdata/analysis/whoop_functions.py
+++ b/whoopdata/analysis/whoop_functions.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 from typing import Any
 import pandas as pd
 import requests
+TOKEN_URL = "https://api.prod.whoop.com/oauth/oauth2/token"
 
 
 def whoop_authentication(username: str, password: str) -> str:
     """
-    Authenticates a user with the `WHOOP API` using `OAuth` and retrieves an access token.
+    Deprecated helper for legacy analysis scripts.
+
+    Authenticates a user with the WHOOP OAuth token endpoint and retrieves an
+    access token using the password grant flow if the app still supports it.
+    New integrations should prefer the OAuth 2.0 browser-based flow used by the
+    maintained WHOOP clients in this repository.
 
     This function sends a `POST` request to the `WHOOP API` with the user's credentials.
     Upon successful authentication,it returns an access token that can be used for subsequent API requests. This function is specifically designed
@@ -30,13 +36,13 @@ def whoop_authentication(username: str, password: str) -> str:
     >>> print(access_token)
     """
     r = requests.post(
-        "https://api-7.whoop.com/oauth/token",
-        json={
-            "issueRefresh": False,
-            "password": password,
-            "username": username,
+        TOKEN_URL,
+        data={
             "grant_type": "password",
+            "username": username,
+            "password": password,
         },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
 
     if r.status_code != 200:
@@ -69,7 +75,7 @@ def make_paginated_request(url: str, headers: dict[str, Any]) -> pd.DataFrame:
     - It prints the `'next_token'` of each request and the total number of records returned for debugging purposes.
 
     Example:
-    >>> url = 'https://api.prod.whoop.com/developer/v1/recovery/'
+    >>> url = 'https://api.prod.whoop.com/developer/v2/recovery/'
     >>> headers = {'Authorization': 'Bearer your_access_token'}
     >>> df = make_paginated_request(url, headers)
     >>> print(df.head())

--- a/whoopdata/api/legacy_route_deprecation.py
+++ b/whoopdata/api/legacy_route_deprecation.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 from fastapi.routing import APIRoute
+from starlette.responses import PlainTextResponse
 
 from whoopdata.api.public_surface_contract import (
     LEGACY_COMPATIBILITY_REMOVAL_DATE,
@@ -121,12 +122,13 @@ def configure_legacy_route_deprecation(
 
     @app.middleware("http")
     async def add_legacy_route_headers(request: Request, call_next):
-        response = await call_next(request)
-        route = request.scope.get("route")
-        if not isinstance(route, APIRoute):
-            return response
-
-        entry = legacy_route_index.get((request.method, route.path))
+        entry = legacy_route_index.get((request.method, request.url.path))
+        try:
+            response = await call_next(request)
+        except Exception:
+            if entry is None:
+                raise
+            response = PlainTextResponse("Internal Server Error", status_code=500)
         if entry is None:
             return response
 

--- a/whoopdata/clients/whoop_client.py
+++ b/whoopdata/clients/whoop_client.py
@@ -25,11 +25,11 @@ class Whoop:
     TOKEN_URL = "https://api.prod.whoop.com/oauth/oauth2/token"  # OAuth 2.0 token endpoint
 
     ENDPOINTS = {
-        "recovery": "https://api.prod.whoop.com/developer/v1/recovery",
-        "sleep": "https://api.prod.whoop.com/developer/v1/activity/sleep",
-        "workout": "https://api.prod.whoop.com/developer/v1/activity/workout",
-        "strain": "https://api.prod.whoop.com/developer/v1/cycle",
-        "body": "https://api.prod.whoop.com/developer/v1/user/measurement/body",
+        "recovery": "https://api.prod.whoop.com/developer/v2/recovery",
+        "sleep": "https://api.prod.whoop.com/developer/v2/activity/sleep",
+        "workout": "https://api.prod.whoop.com/developer/v2/activity/workout",
+        "strain": "https://api.prod.whoop.com/developer/v2/cycle",
+        "body": "https://api.prod.whoop.com/developer/v2/user/measurement/body",
     }
 
     def __init__(
@@ -172,7 +172,7 @@ class Whoop:
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "scope": "read:recovery read:sleep read:workout read:profile read:body_measurement",
+            "scope": "read:recovery read:cycles read:sleep read:workout read:profile read:body_measurement",
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -420,12 +420,12 @@ class Whoop:
             "score.altitude_gain_meter": "altitude_gain_meter",
             "score.altitude_change_meter": "altitude_change_meter",
             # Zone duration fields (convert from milliseconds to minutes)
-            "score.zone_duration.zone_zero_milli": "zone_zero_minutes",
-            "score.zone_duration.zone_one_milli": "zone_one_minutes",
-            "score.zone_duration.zone_two_milli": "zone_two_minutes",
-            "score.zone_duration.zone_three_milli": "zone_three_minutes",
-            "score.zone_duration.zone_four_milli": "zone_four_minutes",
-            "score.zone_duration.zone_five_milli": "zone_five_minutes",
+            "score.zone_durations.zone_zero_milli": "zone_zero_minutes",
+            "score.zone_durations.zone_one_milli": "zone_one_minutes",
+            "score.zone_durations.zone_two_milli": "zone_two_minutes",
+            "score.zone_durations.zone_three_milli": "zone_three_minutes",
+            "score.zone_durations.zone_four_milli": "zone_four_minutes",
+            "score.zone_durations.zone_five_milli": "zone_five_minutes",
         }
 
         df = df.rename(columns=rename_map)
@@ -494,12 +494,7 @@ class Whoop:
             return pd.json_normalize(response_data)
 
 
-whoops = Whoop()
-
-whoops.authenticate()
-
-whoops.make_paginated_request(data_endpoint="https://api.prod.whoop.com/developer/v1/recovery/")
-
-
-# whoops.available_endpoints[0]
-# whoops.get_endpoint_url(whoops.available_endpoints[0])
+if __name__ == "__main__":
+    whoops = Whoop()
+    whoops.authenticate()
+    whoops.make_paginated_request(data_endpoint=whoops.get_endpoint_url("recovery"))


### PR DESCRIPTION
## Summary
- migrate the remaining WHOOP v1 client, script, and config references to WHOOP v2
- add regression coverage for v2 endpoint selection, field mapping, and UUID identifier handling
- fix legacy deprecation header behavior and stabilize the protein tool test so the suite is green again

## Validation
- uv run pytest
- make etl (auth flow reaches interactive browser fallback for WHOOP apps that do not allow client_credentials)
- verified local sleep/workout whoop_id values are UUID strings

Co-Authored-By: Oz <oz-agent@warp.dev>