### PR TITLE
Add Telegram bot transport for the shared agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,11 @@ OPENWEATHER_API_KEY=your_openweather_api_key_here
 # OPENAI_TEMPERATURE=0.1
 # OPENAI_MAX_TOKENS=2000
 # AGENT_TIMEOUT_SECONDS=30
+# 🤖 Optional: Telegram Bot Configuration
+# Create the bot via @BotFather and keep this token secret
+# TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
+# Optional hardening after first-run ID capture
+# TELEGRAM_ALLOWED_USER_IDS=123456789
+# TELEGRAM_ALLOWED_CHAT_IDS=123456789
+# Optional mode switch (defaults to polling)
+# TELEGRAM_USE_WEBHOOK=false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev sync run server etl chat analytics langgraph-dev dev-all test format lint typecheck clean verify
+.PHONY: help install dev sync run server etl chat telegram-bot analytics langgraph-dev dev-all test format lint typecheck clean verify
 
 # Default target
 help:
@@ -15,6 +15,7 @@ help:
 	@echo "  make etl         - Primary ETL pipeline (incremental load)"
 	@echo "  make etl-full    - Primary ETL pipeline (full load)"
 	@echo "  make chat        - Primary chat interface command"
+	@echo "  make telegram-bot - Telegram bot adapter for the shared agent boundary"
 	@echo "  make analytics   - Primary analytics pipeline command"
 	@echo "  make langgraph-dev - Development-only LangGraph dev server"
 	@echo "  make dev-all     - Convenience FastAPI + LangGraph dev launcher"
@@ -65,6 +66,10 @@ etl-full:
 chat:
 	@echo "💬 Starting chat interface..."
 	uv run python chat_app.py
+
+telegram-bot:
+	@echo "📨 Starting Telegram bot adapter..."
+	uv run whoop-telegram-bot
 
 analytics:
 	@echo "🤖 Running analytics pipeline..."

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The product goal is not just to collect biometrics. It is to make personal healt
 - **Analytics Pipeline** -- Trend analysis, correlation analysis, and multiple linear regression models for recovery and HRV
 - **Chat Agent** -- LangGraph-based agent for natural language queries against your health data
 - **Dashboard** -- Web UI with charts, MLR coefficient tables, partial correlation charts, and correlation heatmaps
+- **Telegram Bot** -- Optional Telegram transport for the shared agent conversation boundary
 
 ## Experience at a glance
 
@@ -132,6 +133,7 @@ This is for development and debugging workflows. It is not a separate product su
 - `make etl-full` -- Canonical full-history ingestion command
 - `make server` -- Canonical FastAPI server for the `data`, `insights`, and `agent` surfaces
 - `make chat` -- Canonical Gradio chat UI backed by the shared conversation boundary
+- `make telegram-bot` -- Telegram bot transport backed by the shared conversation boundary
 - `make analytics` -- Canonical analytics materialization command
 - `make langgraph-dev` -- Development-only LangGraph tooling
 - `uv run whoop-withings-auth` -- Canonical Withings re-auth utility
@@ -142,6 +144,65 @@ This is for development and debugging workflows. It is not a separate product su
 - `make dev-all` -- Combined FastAPI + LangGraph dev helper
 
 Use the primary commands for docs, automation, and repeatable workflows. Treat the convenience launchers as shortcuts rather than the canonical product entrypoints.
+
+## Telegram bot setup
+
+The LangChain Telegram page linked in some examples is a document loader for ingesting Telegram data; it is not the transport used to expose this agent over Telegram. In this repository, Telegram is an optional adapter over the same shared conversation boundary used by the API and Gradio chat UI.
+
+### Required configuration
+
+Add the Telegram bot token to `.env`:
+
+```bash
+TELEGRAM_BOT_TOKEN=your_botfather_token_here
+```
+
+The bot token is a secret. Do not paste it into chat, logs, screenshots, or source control. If it is ever exposed, rotate it in `@BotFather` and update `.env`.
+
+### First-run ID capture
+
+Start the API and the Telegram bot:
+
+```bash
+make server
+make telegram-bot
+```
+
+Message the bot in a private Telegram chat, then use `/whoami` to see your Telegram `user_id` and `chat_id`. In a 1:1 bot chat these values may be identical — that is normal. After that, restrict the bot to your account by setting:
+
+```bash
+TELEGRAM_ALLOWED_USER_IDS=123456789
+TELEGRAM_ALLOWED_CHAT_IDS=123456789
+```
+
+Restart the bot after updating `.env` so the allowlists take effect.
+
+### Runtime model
+
+Telegram runs as a separate transport process over the shared conversation boundary:
+
+```bash
+make server
+make telegram-bot
+```
+
+`make dev-all` starts FastAPI and LangGraph dev tooling, but it does not start the Telegram bot.
+
+### Current Telegram behavior
+
+- Supports `/start` and `/whoami`
+- Supports normal text chat with the shared health-data agent
+- Reuses conversation context per Telegram chat
+- Rejects non-private chats
+- Uses Telegram-only HTML formatting for better rendering without changing Studio/API output
+- Sends agent-generated image artifacts back to Telegram when available
+
+Current limitations:
+
+- Incoming photos/images you send to the bot are not processed yet
+- The bot must be restarted after changing Telegram token or allowlist settings
+
+The Telegram adapter can silently ignore unauthorized users once the allowlists are set. Rotate any token that was ever pasted into chat, logs, or source control before relying on the bot.
 
 ## Rollout Verification Checklist
 
@@ -176,6 +237,7 @@ Run:
   make etl            Primary ETL pipeline (incremental)
   make etl-full       Primary ETL pipeline (full load)
   make chat           Primary chat interface command
+  make telegram-bot   Telegram bot adapter command
   make analytics      Primary analytics pipeline command
   make langgraph-dev  Development-only LangGraph dev server
   make dev-all        Convenience FastAPI + LangGraph dev launcher
@@ -197,6 +259,9 @@ Maintenance:
 
 - **WHOOP 401 errors** -- Delete `.whoop_tokens.json` and re-authenticate
 - **Withings re-auth** -- Run `uv run whoop-withings-auth`
+- **Telegram token rejected** -- Re-copy the current token from `@BotFather`, make sure `.env` contains the full token with no quotes or truncation, then restart `make telegram-bot`
+- **`/whoami` or formatting errors in Telegram** -- Restart the bot after pulling the latest code; Telegram formatting is handled adapter-side and should not affect Studio/API output
+- **Telegram access control not working** -- Confirm `TELEGRAM_ALLOWED_USER_IDS` and `TELEGRAM_ALLOWED_CHAT_IDS` are set in `.env`, then restart the bot
 - **Looking for the right API?** -- Use `/api/v1/data/*` for raw records, `/api/v1/insights/*` for interpreted outputs, and `/api/v1/agent/*` for conversational requests
 - **Need detailed implementation notes?** -- Start in [`docs/README.md`](docs/README.md)
 

--- a/data/prompts/agents/supervisor.md
+++ b/data/prompts/agents/supervisor.md
@@ -68,6 +68,29 @@ Think: Would this response make someone go "Huh, interesting" or just nod and fo
 3. NEVER call the same specialist twice in one turn
 4. If you've called 2+ specialists, you MUST respond — no more tool calls
 
+## Day-of briefing behavior
+
+If the user says things like "set me up for today", "set me up for the day", "how am I looking today", or asks for a day-of briefing, treat that as a request for a concise morning setup. You should:
+
+1. Anchor the response to today's actual date
+2. Pull the key health data for today / latest available values, especially:
+   - recovery score
+   - sleep score and the most useful sleep context
+   - resting heart rate
+   - HRV if available
+   - any other clearly relevant readiness metric
+3. Pull the weather / forecast context for today
+4. Synthesize the result into a nicely formatted daily briefing in your voice, not a raw dump
+
+The output should feel like a polished "today setup" note:
+- a clear date heading
+- a short readiness summary
+- the important metrics presented cleanly
+- weather context
+- 2-3 crisp action-oriented takeaways for the day
+
+Prefer completeness over asking follow-up questions for this specific workflow. If some metrics are missing, say what's missing and still produce the briefing with what you do have.
+
 ## Response style examples
 
 **Good (personality + precision + actionable):**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ dependencies = [
     "openai>=1.59.6",
     # Gradio for chat interface
     "gradio==5.9.1",
+    # Telegram bot transport
+    "python-telegram-bot>=21.0,<23.0",
     # Utility
     "PyYAML==6.0.2",
     "Jinja2==3.1.5",
@@ -92,6 +94,7 @@ dev = [
 whoop-start = "whoopdata.cli:main"
 whoop-etl = "whoopdata.etl:run_complete_etl"
 whoop-withings-auth = "whoopdata.cli:withings_auth_main"
+whoop-telegram-bot = "whoopdata.telegram_bot:main"
 
 [project.urls]
 Homepage = "https://github.com/ald0405/whoop-data"

--- a/tests/test_agent_architecture.py
+++ b/tests/test_agent_architecture.py
@@ -229,6 +229,13 @@ class TestPrompts:
         assert "analytics" in SUPERVISOR_SYSTEM_PROMPT.lower()
         assert "environment" in SUPERVISOR_SYSTEM_PROMPT.lower()
 
+    def test_supervisor_prompt_includes_day_of_briefing_instruction(self):
+        from whoopdata.agent.prompts import SUPERVISOR_SYSTEM_PROMPT
+        prompt = SUPERVISOR_SYSTEM_PROMPT.lower()
+        assert "set me up for today" in prompt
+        assert "recovery score" in prompt
+        assert "weather" in prompt
+
     def test_exercise_prompt_file_exists(self):
         path = Path(__file__).parent.parent / "data" / "prompts" / "agents" / "exercise_sub_agent.md"
         assert path.exists(), f"Exercise prompt not found at {path}"

--- a/tests/test_docs_and_openapi_guidance.py
+++ b/tests/test_docs_and_openapi_guidance.py
@@ -36,9 +36,11 @@ def test_readme_and_makefile_distinguish_surfaces_and_run_modes():
     assert "### Primary Commands" in readme_text
     assert "### Convenience Launchers" in readme_text
     assert "`make server`" in readme_text
+    assert "`make telegram-bot`" in readme_text
     assert "`make run`" in readme_text
     assert "convenience" in readme_text.lower()
     assert "Primary FastAPI server command" in makefile_text
+    assert "Telegram bot adapter" in makefile_text
     assert "Convenience launcher" in makefile_text
 
 

--- a/tests/test_telegram_bot_boundary.py
+++ b/tests/test_telegram_bot_boundary.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+
+from whoopdata.agent.public_response import AgentArtifact, AgentConversationResponse, AgentConversationTurn
+from whoopdata.telegram_bot import TelegramConversationGateway
+
+
+class StubConversationService:
+    def __init__(self, responses: list[AgentConversationResponse]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, str | None, str | None]] = []
+
+    async def send_message(
+        self,
+        *,
+        message: str,
+        session_id: str | None = None,
+        thread_id: str | None = None,
+    ) -> AgentConversationResponse:
+        self.calls.append((message, session_id, thread_id))
+        return self._responses.pop(0)
+
+
+def _response(
+    *,
+    assistant_message: str,
+    session_id: str = "session-1",
+    thread_id: str = "thread-1",
+    artifacts: list[AgentArtifact] | None = None,
+) -> AgentConversationResponse:
+    return AgentConversationResponse(
+        session_id=session_id,
+        thread_id=thread_id,
+        assistant_message=assistant_message,
+        messages=[
+            AgentConversationTurn(role="user", content="hi"),
+            AgentConversationTurn(role="assistant", content=assistant_message),
+        ],
+        artifacts=artifacts or [],
+    )
+
+
+def test_gateway_rejects_group_messages_even_without_allowlists():
+    gateway = TelegramConversationGateway(conversation_service=StubConversationService([]))
+
+    assert gateway.is_authorized(user_id=1, chat_id=2, chat_type="group") is False
+    assert gateway.is_authorized(user_id=1, chat_id=2, chat_type="private") is True
+
+
+def test_gateway_reuses_conversation_binding_per_chat():
+    service = StubConversationService(
+        [
+            _response(assistant_message="First", session_id="session-1", thread_id="thread-1"),
+            _response(assistant_message="Second", session_id="session-1", thread_id="thread-1"),
+        ]
+    )
+    gateway = TelegramConversationGateway(conversation_service=service)
+
+    first = asyncio.run(
+        gateway.handle_text_message(text="hello", user_id=1, chat_id=7, chat_type="private")
+    )
+    second = asyncio.run(
+        gateway.handle_text_message(text="again", user_id=1, chat_id=7, chat_type="private")
+    )
+
+    assert first[0].text == "First"
+    assert second[0].text == "Second"
+    assert service.calls == [
+        ("hello", None, None),
+        ("again", "session-1", "thread-1"),
+    ]
+
+
+def test_gateway_formats_code_and_image_artifacts_for_telegram():
+    png_bytes = b"fake-png"
+    service = StubConversationService(
+        [
+            _response(
+                assistant_message="Here you go.",
+                artifacts=[
+                    AgentArtifact(kind="python_code", content="print('hello')", title="code"),
+                    AgentArtifact(
+                        kind="image",
+                        content=base64.b64encode(png_bytes).decode("utf-8"),
+                        title="plot.png",
+                        mime_type="image/png",
+                    ),
+                ],
+            )
+        ]
+    )
+    gateway = TelegramConversationGateway(conversation_service=service)
+
+    messages = asyncio.run(
+        gateway.handle_text_message(text="show me", user_id=1, chat_id=9, chat_type="private")
+    )
+
+    assert messages[0].text == "Here you go."
+    assert messages[0].parse_mode == "HTML"
+    assert "Generated Python Code" in messages[1].text
+    assert "<pre>print('hello')</pre>" in messages[1].text
+    assert messages[1].parse_mode == "HTML"
+    assert messages[2].photo_bytes == png_bytes
+    assert messages[2].caption == "plot.png"
+
+
+def test_whoami_message_includes_ids_for_first_run_setup():
+    gateway = TelegramConversationGateway(conversation_service=StubConversationService([]))
+
+    messages = gateway.build_whoami_messages(user_id=123, chat_id=456, chat_type="private")
+
+    assert len(messages) == 1
+    assert "123" in messages[0].text
+    assert "456" in messages[0].text
+    assert "TELEGRAM_ALLOWED_USER_IDS" in messages[0].text
+    assert messages[0].parse_mode is None
+
+
+def test_gateway_formats_markdownish_assistant_text_for_telegram_html():
+    service = StubConversationService(
+        [
+            _response(
+                assistant_message="# Summary\n**Great** work.\nUse `make server` next.\n*Italic note*"
+            )
+        ]
+    )
+    gateway = TelegramConversationGateway(conversation_service=service)
+
+    messages = asyncio.run(
+        gateway.handle_text_message(text="format this", user_id=1, chat_id=11, chat_type="private")
+    )
+
+    assert messages[0].parse_mode == "HTML"
+    assert "<b>Summary</b>" in messages[0].text
+    assert "<b>Great</b>" in messages[0].text
+    assert "<code>make server</code>" in messages[0].text
+    assert "<i>Italic note</i>" in messages[0].text

--- a/whoopdata/telegram_bot.py
+++ b/whoopdata/telegram_bot.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import html
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from dotenv import load_dotenv
+from telegram.constants import ParseMode
+
+from whoopdata.agent.conversation_service import ConversationService, get_conversation_service
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_int_set(raw: str | None) -> set[int]:
+    if not raw:
+        return set()
+
+    parsed: set[int] = set()
+    for part in raw.split(","):
+        value = part.strip()
+        if not value:
+            continue
+        parsed.add(int(value))
+    return parsed
+
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_ALLOWED_USER_IDS = _parse_int_set(os.getenv("TELEGRAM_ALLOWED_USER_IDS"))
+TELEGRAM_ALLOWED_CHAT_IDS = _parse_int_set(os.getenv("TELEGRAM_ALLOWED_CHAT_IDS"))
+
+
+@dataclass
+class OutboundTelegramMessage:
+    text: str | None = None
+    photo_bytes: bytes | None = None
+    caption: str | None = None
+    parse_mode: str | None = None
+
+
+@dataclass
+class ConversationBinding:
+    session_id: str | None = None
+    thread_id: str | None = None
+
+
+class TelegramConversationGateway:
+    def __init__(
+        self,
+        *,
+        conversation_service: ConversationService | None = None,
+        allowed_user_ids: Iterable[int] | None = None,
+        allowed_chat_ids: Iterable[int] | None = None,
+    ) -> None:
+        self._conversation_service = conversation_service or get_conversation_service()
+        self._allowed_user_ids = set(allowed_user_ids or ())
+        self._allowed_chat_ids = set(allowed_chat_ids or ())
+        self._bindings_by_chat: dict[int, ConversationBinding] = {}
+
+    def is_authorized(self, *, user_id: int | None, chat_id: int | None, chat_type: str | None) -> bool:
+        if user_id is None or chat_id is None:
+            return False
+
+        if chat_type != "private":
+            return False
+
+        if self._allowed_user_ids and user_id not in self._allowed_user_ids:
+            return False
+
+        if self._allowed_chat_ids and chat_id not in self._allowed_chat_ids:
+            return False
+
+        return True
+
+    def build_whoami_messages(
+        self, *, user_id: int | None, chat_id: int | None, chat_type: str | None
+    ) -> list[OutboundTelegramMessage]:
+        return [
+            OutboundTelegramMessage(
+                text=(
+                    "Telegram identity details:\n"
+                    f"- user_id: {user_id}\n"
+                    f"- chat_id: {chat_id}\n"
+                    f"- chat_type: {chat_type}\n\n"
+                    "Add these to your `.env` as `TELEGRAM_ALLOWED_USER_IDS` and "
+                    "`TELEGRAM_ALLOWED_CHAT_IDS`, then restart the bot to lock it down."
+                )
+            )
+        ]
+
+    async def handle_text_message(
+        self,
+        *,
+        text: str,
+        user_id: int | None,
+        chat_id: int | None,
+        chat_type: str | None,
+    ) -> list[OutboundTelegramMessage]:
+        if not self.is_authorized(user_id=user_id, chat_id=chat_id, chat_type=chat_type):
+            return []
+
+        binding = self._bindings_by_chat.setdefault(chat_id, ConversationBinding())
+        response = await self._conversation_service.send_message(
+            message=text,
+            session_id=binding.session_id,
+            thread_id=binding.thread_id,
+        )
+        binding.session_id = response.session_id
+        binding.thread_id = response.thread_id
+        return self._build_response_messages(response.assistant_message, response.artifacts)
+
+    def _build_response_messages(self, assistant_message: str, artifacts: list) -> list[OutboundTelegramMessage]:
+        messages: list[OutboundTelegramMessage] = []
+
+        if assistant_message:
+            messages.append(
+                OutboundTelegramMessage(
+                    text=_format_text_for_telegram_html(assistant_message),
+                    parse_mode=ParseMode.HTML,
+                )
+            )
+
+        for artifact in artifacts:
+            if artifact.kind == "python_code" and artifact.content:
+                messages.append(
+                    OutboundTelegramMessage(
+                        text=f"Generated Python Code:\n<pre>{artifact.content}</pre>",
+                        parse_mode=ParseMode.HTML,
+                    )
+                )
+            elif artifact.kind == "image" and artifact.content:
+                try:
+                    photo_bytes = base64.b64decode(artifact.content)
+                except Exception:
+                    logger.warning("Skipping invalid Telegram image artifact payload")
+                    continue
+                messages.append(
+                    OutboundTelegramMessage(
+                        photo_bytes=photo_bytes,
+                        caption=artifact.title or "Generated image",
+                    )
+                )
+
+        return messages
+
+
+def _format_text_for_telegram_html(text: str) -> str:
+    escaped = html.escape(text)
+    escaped = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", escaped)
+    escaped = re.sub(r"\*\*([^\n*][^*]*?)\*\*", r"<b>\1</b>", escaped)
+    escaped = re.sub(r"(?<!\*)\*([^\n*][^*]*?)\*(?!\*)", r"<i>\1</i>", escaped)
+    escaped = re.sub(r"^### (.+)$", r"<b>\1</b>", escaped, flags=re.MULTILINE)
+    escaped = re.sub(r"^## (.+)$", r"<b>\1</b>", escaped, flags=re.MULTILINE)
+    escaped = re.sub(r"^# (.+)$", r"<b>\1</b>", escaped, flags=re.MULTILINE)
+    return escaped
+
+
+def _build_gateway() -> TelegramConversationGateway:
+    return TelegramConversationGateway(
+        allowed_user_ids=TELEGRAM_ALLOWED_USER_IDS,
+        allowed_chat_ids=TELEGRAM_ALLOWED_CHAT_IDS,
+    )
+
+
+async def _reply(update, messages: list[OutboundTelegramMessage]) -> None:
+    message = update.effective_message
+    if message is None:
+        return
+
+    for outbound in messages:
+        if outbound.photo_bytes is not None:
+            await message.reply_photo(photo=outbound.photo_bytes, caption=outbound.caption)
+        elif outbound.text:
+            await message.reply_text(outbound.text, parse_mode=outbound.parse_mode)
+
+
+async def start_command(update, context) -> None:
+    gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
+    user = update.effective_user
+    chat = update.effective_chat
+
+    intro = [
+        OutboundTelegramMessage(
+            text=(
+                "Health Data Agent is online.\n"
+                "Use `/whoami` to capture your Telegram IDs for allowlisting, then add "
+                "`TELEGRAM_ALLOWED_USER_IDS` and `TELEGRAM_ALLOWED_CHAT_IDS` to `.env`."
+            )
+        )
+    ]
+    if not gateway._allowed_user_ids and not gateway._allowed_chat_ids:
+        intro.extend(
+            gateway.build_whoami_messages(
+                user_id=getattr(user, "id", None),
+                chat_id=getattr(chat, "id", None),
+                chat_type=getattr(chat, "type", None),
+            )
+        )
+    await _reply(update, intro)
+
+
+async def whoami_command(update, context) -> None:
+    gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
+    user = update.effective_user
+    chat = update.effective_chat
+    await _reply(
+        update,
+        gateway.build_whoami_messages(
+            user_id=getattr(user, "id", None),
+            chat_id=getattr(chat, "id", None),
+            chat_type=getattr(chat, "type", None),
+        ),
+    )
+
+
+async def text_message(update, context) -> None:
+    gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
+    user = update.effective_user
+    chat = update.effective_chat
+    message = update.effective_message
+    text = getattr(message, "text", None)
+    if not text:
+        return
+
+    responses = await gateway.handle_text_message(
+        text=text,
+        user_id=getattr(user, "id", None),
+        chat_id=getattr(chat, "id", None),
+        chat_type=getattr(chat, "type", None),
+    )
+    await _reply(update, responses)
+
+
+async def error_handler(update, context) -> None:
+    logger.exception("Telegram bot error: %s", context.error)
+    if getattr(update, "effective_message", None) is not None:
+        await update.effective_message.reply_text("Sorry, I hit an error processing that message.")
+
+
+def build_application(gateway: TelegramConversationGateway | None = None):
+    if not TELEGRAM_BOT_TOKEN:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN is required to start the Telegram bot")
+
+    from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, filters
+
+    application = ApplicationBuilder().token(TELEGRAM_BOT_TOKEN).build()
+    application.bot_data["gateway"] = gateway or _build_gateway()
+    application.add_handler(CommandHandler("start", start_command))
+    application.add_handler(CommandHandler("whoami", whoami_command))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text_message))
+    application.add_error_handler(error_handler)
+    return application
+
+
+async def run_bot() -> None:
+    application = build_application()
+    await application.initialize()
+    await application.start()
+    await application.updater.start_polling()
+    logger.info("Telegram bot polling started")
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await application.updater.stop()
+        await application.stop()
+        await application.shutdown()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(run_bot())


### PR DESCRIPTION
## Summary
- add a Telegram bot adapter over the existing shared conversation boundary
- support first-run ID capture, allowlist-based access control, and Telegram-only HTML formatting
- document Telegram setup and add supervisor guidance for day-of briefings

## Validation
- uv run pytest tests/test_telegram_bot_boundary.py
- uv run pytest tests/test_agent_architecture.py
- uv run pytest tests/test_chat_app_boundary.py tests/test_agent_routes.py tests/test_docs_and_openapi_guidance.py

Co-Authored-By: Oz <oz-agent@warp.dev>