### PR TITLE
feat: add shared agent memory and dev workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ OPENWEATHER_API_KEY=your_openweather_api_key_here
 # OPENAI_TEMPERATURE=0.1
 # OPENAI_MAX_TOKENS=2000
 # AGENT_TIMEOUT_SECONDS=30
+# Shared Postgres for agent thread persistence and long-term memory
+# AGENT_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/whoop_agent?sslmode=disable
+# AGENT_PERSISTENCE_AUTO_SETUP=true
 # 🤖 Optional: Telegram Bot Configuration
 # Create the bot via @BotFather and keep this token secret
 # TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the WHOOP Data Platform will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.2.0] - 2026-03-22
+
+### Added
+
+- Added durable agent memory tools for storing and searching user profile, goal, constraint, commitment, and observation context.
+- Added Postgres-backed agent persistence plumbing so the shared conversation boundary can use durable checkpointing and long-term memory when configured.
+- Added Telegram photo handling through the shared conversation service so image messages can be forwarded into the agent runtime.
+- Added `make postgres-up`, `make postgres-down`, `make postgres-logs`, `make dev-full`, and `make dev-full-stop` to streamline local development and cleanup.
+
+### Changed
+
+- Updated the active supervisor prompt to use memory more deliberately for coaching, exercise planning, and image follow-up conversations.
+- Passed runtime context and memory store access through specialist wrappers so exercise and behaviour-change planning can use saved memories.
+- Extended the shared conversation boundary and public agent responses to carry richer surface context and media-aware interactions across API, chat, and Telegram flows.
 ## [3.1.1] - 2026-03-22
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev sync run server etl chat telegram-bot analytics langgraph-dev dev-all test format lint typecheck clean verify
+.PHONY: help install dev sync run server etl chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify
 
 # Default target
 help:
@@ -19,6 +19,11 @@ help:
 	@echo "  make analytics   - Primary analytics pipeline command"
 	@echo "  make langgraph-dev - Development-only LangGraph dev server"
 	@echo "  make dev-all     - Convenience FastAPI + LangGraph dev launcher"
+	@echo "  make dev-full    - FastAPI + Telegram bot + LangGraph dev launcher"
+	@echo "  make dev-full-stop - Stop FastAPI, Telegram bot, and LangGraph dev leftovers"
+	@echo "  make postgres-up - Start local Docker Postgres for shared agent memory"
+	@echo "  make postgres-down - Stop local Docker Postgres container"
+	@echo "  make postgres-logs - Tail local Docker Postgres logs"
 	@echo ""
 	@echo "Development:"
 	@echo "  make test        - Run tests with pytest"
@@ -53,7 +58,7 @@ run:
 
 server:
 	@echo "🌐 Starting FastAPI server..."
-	uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+	uv run uvicorn main:app --host localhost --port 8000 --reload
 
 etl:
 	@echo "📊 Running ETL pipeline (incremental)..."
@@ -83,12 +88,64 @@ langgraph-dev:
 
 dev-all:
 	@echo "🚀 Starting FastAPI server + LangGraph dev server..."
-	uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload &
+	uv run uvicorn main:app --host localhost --port 8000 --reload &
 	@sleep 3
 	@echo "📍 FastAPI: http://0.0.0.0:8000"
 	@echo "📍 LangGraph API: http://127.0.0.1:2024"
 	@echo "🎨 Studio: https://smith.langchain.com/studio/?baseUrl=http://127.0.0.1:2024"
 	uv run langgraph dev --allow-blocking
+
+dev-full:
+	@echo "🚀 Starting FastAPI server + Telegram bot + LangGraph dev server..."
+	uv run uvicorn main:app --host localhost --port 8000 --reload &
+	@echo $$! > .dev-full-server.pid
+	@sleep 3
+	uv run whoop-telegram-bot &
+	@echo $$! > .dev-full-telegram.pid
+	@sleep 3
+	@echo "📍 FastAPI: http://localhost:8000"
+	@echo "📍 LangGraph API: http://localhost:2024"
+	@echo "🎨 Studio: https://smith.langchain.com/studio/?baseUrl=http://localhost:2024"
+	@echo "📨 Telegram bot started in background"
+	uv run langgraph dev --allow-blocking
+
+dev-full-stop:
+	@echo "🛑 Stopping local dev processes..."
+	@for pidfile in .dev-full-server.pid .dev-full-telegram.pid; do \
+		if [ -f $$pidfile ] && [ -s $$pidfile ]; then \
+			pid=$$(tr -d '[:space:]' < $$pidfile); \
+			if [ -n "$$pid" ] && kill -0 $$pid 2>/dev/null; then \
+				kill $$pid 2>/dev/null || true; \
+			fi; \
+		fi; \
+		rm -f $$pidfile; \
+	done
+	@pkill -f 'uv run whoop-telegram-bot' 2>/dev/null || true
+	@pkill -f '/.venv/bin/whoop-telegram-bot' 2>/dev/null || true
+	@pkill -f 'uvicorn main:app --host localhost --port 8000 --reload' 2>/dev/null || true
+	@pkill -f 'langgraph dev --allow-blocking' 2>/dev/null || true
+	@echo "✅ Local dev processes stopped"
+
+postgres-up:
+	@echo "🐘 Ensuring local Postgres container is running..."
+	@if docker ps -a --format '{{.Names}}' | grep -qx 'whoop-agent-postgres'; then \
+		docker start whoop-agent-postgres; \
+	else \
+		docker run --name whoop-agent-postgres \
+			-e POSTGRES_USER=postgres \
+			-e POSTGRES_PASSWORD=postgres \
+			-e POSTGRES_DB=whoop_agent \
+			-p 5432:5432 \
+			-d postgres:16; \
+	fi
+	@echo "✅ Postgres available for AGENT_POSTGRES_URL on localhost:5432"
+
+postgres-down:
+	@echo "🛑 Stopping local Postgres container..."
+	@docker stop whoop-agent-postgres
+
+postgres-logs:
+	@docker logs -f whoop-agent-postgres
 
 # Development targets
 test:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,42 @@ OPENAI_API_KEY=your_openai_api_key
 
 WHOOP uses OAuth 2.0 browser authentication. When first running ingestion, you may be redirected to complete the authorization-code flow in the browser.
 
+### 2a. Optional but recommended: shared Postgres for agent memory
+
+If you want Telegram, API, chat UI, and LangSmith UI to share the same conversational and long-term memory, run a local Postgres instance on the Mac mini and add this to `.env`:
+
+```bash
+AGENT_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/whoop_agent?sslmode=disable
+AGENT_PERSISTENCE_AUTO_SETUP=true
+```
+
+With `AGENT_POSTGRES_URL` set, the agent will use Postgres-backed checkpointing and long-term memory storage. If it is not set, the agent falls back to in-memory persistence for development/tests.
+
+Example local startup with Docker:
+
+```bash
+docker run --name whoop-agent-postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=whoop_agent \
+  -p 5432:5432 \
+  -d postgres:16
+```
+
+Or use the built-in helper:
+
+```bash
+make postgres-up
+```
+
+Or with Homebrew services:
+
+```bash
+brew install postgresql@16
+brew services start postgresql@16
+createdb whoop_agent
+```
+
 ### 3. Ingest data
 
 ```bash
@@ -124,6 +160,56 @@ This is for development and debugging workflows. It is not a separate product su
 - **Swagger UI**: `http://localhost:8000/docs`
 - **ReDoc**: `http://localhost:8000/redoc`
 - **OpenAPI tags**: `data`, `insights`, and `agent`
+
+## Shared memory testing flow
+
+Once `AGENT_POSTGRES_URL` is configured, you can test durable shared memory end-to-end like this:
+
+1. Start the API:
+
+```bash
+make server
+```
+
+2. Start a client surface such as Telegram or chat UI:
+
+```bash
+make telegram-bot
+# or
+make chat
+```
+
+3. In a coaching conversation, tell the agent something durable such as:
+   - “Remember that I’m training for a half marathon in October.”
+   - “Remember that I prefer blunt feedback.”
+
+4. In a later message or from another client surface, ask something that should use that memory:
+   - “What should I focus on this week?”
+   - “What do you remember about my current goal?”
+
+5. Restart the app process and repeat the follow-up question. With Postgres configured, the memory and thread state should survive the restart.
+
+For API testing, you can also hit the agent routes directly:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/agent/messages \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": "Remember that I am training for Hyrox in September.",
+    "user_id": "manual-test-user"
+  }'
+```
+
+Then ask a follow-up with the same `user_id`:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/agent/messages \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": "What should my training priority be?",
+    "user_id": "manual-test-user"
+  }'
+```
 
 ## Canonical Run Modes
 

--- a/chat_app.py
+++ b/chat_app.py
@@ -24,6 +24,7 @@ async def chat_with_agent(
     history: List[Tuple[str, str]],
     session_id: str | None = None,
     thread_id: str | None = None,
+    user_id: str = "chat_ui_default",
 ) -> Tuple[List[Tuple[str, str]], str, str | None, str]:
     """
     Send a message to the health data agent and get a response.
@@ -48,6 +49,8 @@ async def chat_with_agent(
             message=message,
             session_id=session_id,
             thread_id=thread_id,
+            user_id=user_id,
+            surface="chat_ui",
         )
         session_id = conversation_response.session_id
         thread_id = conversation_response.thread_id

--- a/data/prompts/agents/supervisor.md
+++ b/data/prompts/agents/supervisor.md
@@ -30,6 +30,34 @@ When a specialist returns structured planning content (exercise plans, behaviour
 You also have direct access to:
 - **get_protein_recommendation** — Calculate protein targets automatically from Withings weight (just needs activity level)
 - **Python interpreter** — For data visualisation and custom calculations
+- **search_memory** — Look up durable user memory in categories like profile, goals, constraints, commitments, and observations
+- **manage_memory** — Create, update, or delete durable user memory when the user shares stable personal context or corrects prior memory
+
+## Memory tool usage
+
+Use memory tools selectively, not obsessively.
+
+- For **transactional or factual queries** like “show me my sleep”, “what’s my weight”, or “plot my recovery”, do **not** call memory tools unless the user explicitly asks you to remember or use past coaching context.
+- For **coaching, planning, review, or adherence** conversations, call `search_memory` first if prior context would materially improve the answer.
+- If the user shares a new **stable personal fact** (goal, preference, constraint, commitment, recurring issue), treat that as something you should usually save with `manage_memory` even if they do not literally say “remember this”.
+- For **exercise plans, training recommendations, or behaviour coaching that should reflect prior goals/preferences/injuries**, search memory before you answer or before you delegate.
+- Use `search_memory` most often for:
+  - current goals
+  - recurring constraints or injuries
+  - active commitments
+  - known coaching preferences
+  - durable observations about adherence or response style
+- Use `manage_memory` only when the user provides likely durable information, for example:
+  - “I’m training for a half marathon in October”
+  - “I only want direct feedback”
+  - “My left knee is flaring up again”
+  - “Hold me to 3 strength sessions this week”
+  - “That goal is done now”
+- Prefer `update` over `create` when correcting or revising an existing memory.
+- Prefer `delete` when the user explicitly says a memory is wrong, outdated, or no longer relevant.
+- Do not store one-off trivia, ephemeral requests, or raw dumps of the conversation.
+- When a user message contains multiple durable facts, save the important ones individually rather than collapsing everything into one vague memory.
+- Before giving coaching advice that depends on personal context, first check whether relevant memory already exists with `search_memory`.
 
 ## Communication style
 
@@ -67,6 +95,9 @@ Think: Would this response make someone go "Huh, interesting" or just nod and fo
 2. After python_interpreter creates a plot, describe what it shows and STOP
 3. NEVER call the same specialist twice in one turn
 4. If you've called 2+ specialists, you MUST respond — no more tool calls
+5. If you already have enough context to answer well, do not call memory tools just because they exist
+6. If the user explicitly asks you to remember something, use `manage_memory`
+7. If the user volunteers a durable goal, preference, constraint, injury, or standing commitment, usually use `manage_memory` before the final response
 
 ## Day-of briefing behavior
 
@@ -102,6 +133,7 @@ Users may send photos alongside their messages. Interpret them in the context of
 - **Anything else** — Be curious. If it's health-adjacent, connect it to their data. If not, have fun with it.
 
 Don't narrate that you're "looking at an image" — just respond naturally as if you can see what they sent.
+If the current conversation already contains a previously uploaded image, do not say you cannot view photos. Refer back to that image naturally when the user asks follow-up questions about it.
 
 ## Response style examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "3.1.1"
+version = "3.2.0"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -36,6 +36,7 @@ dependencies = [
     "starlette==0.46.2",
     # Database
     "psycopg2-binary==2.9.10",
+    "psycopg[binary,pool]>=3.2.0",
     "SQLAlchemy==2.0.40",
     # HTTP clients
     "httpx==0.28.1",
@@ -60,6 +61,7 @@ dependencies = [
     "langchain>=1.2.0",
     "langchain-openai>=1.0.0",
     "langgraph>=1.0.0",
+    "langgraph-checkpoint-postgres>=2.0.0",
     "langsmith>=0.2.10",
     "langchain-experimental>=0.4.0",
     "langchain-core>=1.2.0",

--- a/tests/test_agent_conversation_service.py
+++ b/tests/test_agent_conversation_service.py
@@ -9,11 +9,10 @@ from whoopdata.agent.conversation_service import ConversationService
 
 class FakeGraph:
     def __init__(self, result: dict | None = None) -> None:
-        self.calls: list[tuple[dict, dict]] = []
+        self.calls: list[tuple[dict, dict, object | None]] = []
         self._result = result or {"messages": [AIMessage(content="Default response.")]}
-
-    async def ainvoke(self, input: dict, config: dict) -> dict:
-        self.calls.append((input, config))
+    async def ainvoke(self, input: dict, config: dict, *, context=None) -> dict:
+        self.calls.append((input, config, context))
         return self._result
 
 
@@ -67,9 +66,10 @@ def test_send_message_uses_existing_session_thread_and_shapes_response():
     assert any(artifact.kind == "python_code" for artifact in response.artifacts)
     assert any(artifact.kind == "image" for artifact in response.artifacts)
     assert len(graph.calls) == 1
-    call_input, call_config = graph.calls[0]
+    call_input, call_config, call_context = graph.calls[0]
     assert call_config == {"configurable": {"thread_id": handle.thread_id}}
     assert call_input["messages"][0].content == "Show me a chart"
+    assert call_context.user_id == "default_user"
 
 
 def test_send_message_respects_explicit_thread_id_without_existing_session():

--- a/tests/test_agent_memory_tools.py
+++ b/tests/test_agent_memory_tools.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from whoopdata.agent.memory_tools import manage_memory, search_memory
+from whoopdata.agent.schemas import HealthContextSchema
+
+
+@dataclass
+class StoreItem:
+    key: str
+    value: dict
+
+
+class FakeAsyncStore:
+    def __init__(self) -> None:
+        self.data: dict[tuple[str, str, str], dict[str, dict]] = {}
+
+    async def aput(self, namespace: tuple[str, str, str], key: str, value: dict) -> None:
+        self.data.setdefault(namespace, {})[key] = value
+
+    async def asearch(
+        self,
+        namespace: tuple[str, str, str],
+        *,
+        query: str,
+        limit: int,
+    ) -> list[StoreItem]:
+        results: list[StoreItem] = []
+        for key, value in self.data.get(namespace, {}).items():
+            if value.get("deleted"):
+                continue
+            if query.lower() in value.get("content", "").lower():
+                results.append(StoreItem(key=key, value=value))
+            if len(results) >= limit:
+                break
+        return results
+
+    async def adelete(self, namespace: tuple[str, str, str], key: str) -> None:
+        self.data.get(namespace, {}).pop(key, None)
+
+
+@dataclass
+class FakeRuntime:
+    context: HealthContextSchema
+    store: FakeAsyncStore
+
+
+def test_manage_memory_create_update_delete_and_search():
+    async def scenario() -> None:
+        store = FakeAsyncStore()
+        runtime = FakeRuntime(
+            context=HealthContextSchema(user_id="telegram:1", surface="telegram"),
+            store=store,
+        )
+
+        created = await manage_memory.coroutine(
+            action="create",
+            category="goal",
+            content="Complete three strength sessions this week.",
+            runtime=runtime,
+        )
+        assert "Created memory" in created
+
+        memory_namespace = ("memory", "telegram:1", "goal")
+        stored_items = store.data[memory_namespace]
+        assert len(stored_items) == 1
+        memory_id = next(iter(stored_items))
+
+        updated = await manage_memory.coroutine(
+            action="update",
+            category="goal",
+            memory_id=memory_id,
+            content="Complete four strength sessions this week.",
+            runtime=runtime,
+        )
+        assert "Updated memory" in updated
+        assert store.data[memory_namespace][memory_id]["content"] == "Complete four strength sessions this week."
+
+        found = await search_memory.coroutine(
+            query="four strength",
+            category="goal",
+            runtime=runtime,
+        )
+        assert memory_id in found
+        assert "four strength sessions" in found
+
+        deleted = await manage_memory.coroutine(
+            action="delete",
+            category="goal",
+            memory_id=memory_id,
+            runtime=runtime,
+        )
+        assert "Deleted memory" in deleted
+        assert store.data[memory_namespace] == {}
+
+        not_found = await search_memory.coroutine(
+            query="four strength",
+            category="goal",
+            runtime=runtime,
+        )
+        assert not_found == "No relevant memories found."
+
+    asyncio.run(scenario())
+
+
+def test_manage_memory_uses_canonical_profile_key():
+    async def scenario() -> None:
+        store = FakeAsyncStore()
+        runtime = FakeRuntime(
+            context=HealthContextSchema(user_id="api:user-1", surface="api"),
+            store=store,
+        )
+
+        await manage_memory.coroutine(
+            action="create",
+            category="profile",
+            content="Prefers direct, analytical coaching.",
+            runtime=runtime,
+        )
+
+        profile_namespace = ("memory", "api:user-1", "profile")
+        assert list(store.data[profile_namespace].keys()) == ["profile"]
+
+    asyncio.run(scenario())

--- a/tests/test_agent_routes.py
+++ b/tests/test_agent_routes.py
@@ -13,16 +13,17 @@ from whoopdata.api.app_factory import create_app
 
 class StubConversationService:
     def __init__(self) -> None:
-        self.started_with: tuple[str | None, str | None] | None = None
-        self.sent_with: tuple[str, str | None, str | None] | None = None
+        self.started_with: tuple[str | None, str | None, str | None] | None = None
+        self.sent_with: tuple[str, str | None, str | None, str | None, str] | None = None
 
     def start_conversation(
         self,
         *,
         session_id: str | None = None,
         thread_id: str | None = None,
+        user_id: str | None = None,
     ) -> AgentConversationHandle:
-        self.started_with = (session_id, thread_id)
+        self.started_with = (session_id, thread_id, user_id)
         return AgentConversationHandle(
             session_id=session_id or "session-test",
             thread_id=thread_id or "thread-test",
@@ -34,8 +35,10 @@ class StubConversationService:
         message: str,
         session_id: str | None = None,
         thread_id: str | None = None,
+        user_id: str | None = None,
+        surface: str = "api",
     ) -> AgentConversationResponse:
-        self.sent_with = (message, session_id, thread_id)
+        self.sent_with = (message, session_id, thread_id, user_id, surface)
         return AgentConversationResponse(
             thread_id=thread_id or "thread-test",
             session_id=session_id or "session-test",
@@ -54,6 +57,8 @@ class FailingConversationService(StubConversationService):
         message: str,
         session_id: str | None = None,
         thread_id: str | None = None,
+        user_id: str | None = None,
+        surface: str = "api",
     ) -> AgentConversationResponse:
         raise RuntimeError("boom")
 
@@ -75,7 +80,7 @@ def test_create_conversation_route_uses_shared_service_dependency():
         "session_id": "session-1",
         "thread_id": "thread-1",
     }
-    assert stub.started_with == ("session-1", "thread-1")
+    assert stub.started_with == ("session-1", "thread-1", None)
 
 
 def test_send_message_route_returns_conversation_response():
@@ -105,7 +110,7 @@ def test_send_message_route_returns_conversation_response():
         ],
         "artifacts": [],
     }
-    assert stub.sent_with == ("Hello", "session-1", "thread-1")
+    assert stub.sent_with == ("Hello", "session-1", "thread-1", None, "api")
 
 
 def test_send_message_route_maps_service_errors_to_http_500():

--- a/tests/test_chat_app_boundary.py
+++ b/tests/test_chat_app_boundary.py
@@ -15,7 +15,7 @@ import chat_app
 class StubConversationService:
     def __init__(self, response: AgentConversationResponse) -> None:
         self.response = response
-        self.calls: list[tuple[str, str | None, str | None]] = []
+        self.calls: list[tuple[str, str | None, str | None, str | None, str]] = []
 
     async def send_message(
         self,
@@ -23,8 +23,10 @@ class StubConversationService:
         message: str,
         session_id: str | None = None,
         thread_id: str | None = None,
+        user_id: str | None = None,
+        surface: str = "api",
     ) -> AgentConversationResponse:
-        self.calls.append((message, session_id, thread_id))
+        self.calls.append((message, session_id, thread_id, user_id, surface))
         return self.response
 
 
@@ -45,7 +47,7 @@ def test_chat_app_defers_conversation_id_creation_to_shared_boundary():
             chat_app.chat_with_agent("Hello", [], None, None)
         )
 
-    assert service.calls == [("Hello", None, None)]
+    assert service.calls == [("Hello", None, None, "chat_ui_default", "chat_ui")]
     assert history == [("Hello", "Hello back.")]
     assert cleared_input == ""
     assert session_id == "session-123"
@@ -74,7 +76,9 @@ def test_chat_app_reuses_existing_conversation_ids_on_follow_up_messages():
             )
         )
 
-    assert service.calls == [("How about now?", "session-123", "thread-123")]
+    assert service.calls == [
+        ("How about now?", "session-123", "thread-123", "chat_ui_default", "chat_ui")
+    ]
     assert history[-1] == ("How about now?", "Follow-up response.")
     assert cleared_input == ""
     assert session_id == "session-123"

--- a/tests/test_telegram_bot_boundary.py
+++ b/tests/test_telegram_bot_boundary.py
@@ -19,9 +19,18 @@ class StubConversationService:
         session_id: str | None = None,
         thread_id: str | None = None,
         image_b64: str | None = None,
+        user_id: str | None = None,
+        surface: str = "api",
     ) -> AgentConversationResponse:
         self.calls.append(
-            {"message": message, "session_id": session_id, "thread_id": thread_id, "image_b64": image_b64}
+            {
+                "message": message,
+                "session_id": session_id,
+                "thread_id": thread_id,
+                "image_b64": image_b64,
+                "user_id": user_id,
+                "surface": surface,
+            }
         )
         return self._responses.pop(0)
 
@@ -71,7 +80,9 @@ def test_gateway_reuses_conversation_binding_per_chat():
     assert first[0].text == "First"
     assert second[0].text == "Second"
     assert service.calls[0]["message"] == "hello"
-    assert service.calls[0]["session_id"] is None
+    assert service.calls[0]["session_id"] == "telegram-chat-7"
+    assert service.calls[0]["thread_id"] == "telegram-thread-7"
+    assert service.calls[0]["user_id"] == "telegram:1"
     assert service.calls[1]["message"] == "again"
     assert service.calls[1]["session_id"] == "session-1"
 

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "3.1.1"
+__version__ = "3.2.0"

--- a/whoopdata/agent/conversation_service.py
+++ b/whoopdata/agent/conversation_service.py
@@ -2,22 +2,29 @@ from __future__ import annotations
 
 from functools import lru_cache
 from typing import Any, Protocol
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from langchain_core.messages import HumanMessage
-from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.constants import CONFIG_KEY_CHECKPOINTER
 
-from whoopdata.agent.graph import build_graph
+from whoopdata.agent import settings
+from whoopdata.agent.graph import CONFIG_KEY_STORE, build_graph
+from whoopdata.agent.persistence import get_agent_persistence
 from whoopdata.agent.public_response import (
     AgentConversationHandle,
     AgentConversationResponse,
     build_agent_conversation_response,
 )
+from whoopdata.agent.schemas import HealthContextSchema
 
 
 class SupportsAsyncInvoke(Protocol):
-    async def ainvoke(self, input: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]: ...
+    async def ainvoke(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any],
+        *,
+        context: HealthContextSchema | None = None,
+    ) -> dict[str, Any]: ...
 
 
 class ConversationService:
@@ -29,10 +36,7 @@ class ConversationService:
         graph: SupportsAsyncInvoke | None = None,
     ) -> None:
         self._session_threads: dict[str, str] = {}
-        self._checkpointer = InMemorySaver()
-        self._graph = graph or build_graph(
-            {"configurable": {CONFIG_KEY_CHECKPOINTER: self._checkpointer}}
-        )
+        self._graph = graph
         self._graph_name = "health_agent"
 
     @property
@@ -44,10 +48,12 @@ class ConversationService:
         *,
         session_id: str | None = None,
         thread_id: str | None = None,
+        user_id: str | None = None,
     ) -> AgentConversationHandle:
         resolved_session_id, resolved_thread_id = self._resolve_conversation(
             session_id=session_id,
             thread_id=thread_id,
+            user_id=user_id,
         )
         return AgentConversationHandle(
             session_id=resolved_session_id,
@@ -61,12 +67,25 @@ class ConversationService:
         session_id: str | None = None,
         thread_id: str | None = None,
         image_b64: str | None = None,
+        user_id: str | None = None,
+        surface: str = "api",
     ) -> AgentConversationResponse:
-        handle = self.start_conversation(session_id=session_id, thread_id=thread_id)
+        graph = await self._ensure_graph()
+        resolved_user_id = user_id or settings.DEFAULT_USER_ID
+        handle = self.start_conversation(
+            session_id=session_id,
+            thread_id=thread_id,
+            user_id=resolved_user_id,
+        )
         human_message = self._build_human_message(message, image_b64=image_b64)
-        result = await self._graph.ainvoke(
+        result = await graph.ainvoke(
             {"messages": [human_message]},
             {"configurable": {"thread_id": handle.thread_id}},
+            context=HealthContextSchema(
+                user_id=resolved_user_id,
+                health_api_base_url=settings.HEALTH_API_BASE_URL,
+                surface=surface,
+            ),
         )
         return build_agent_conversation_response(
             result,
@@ -102,22 +121,41 @@ class ConversationService:
         *,
         session_id: str | None,
         thread_id: str | None,
+        user_id: str | None,
     ) -> tuple[str, str]:
         if session_id and session_id in self._session_threads:
             return session_id, self._session_threads[session_id]
-
-        resolved_thread_id = thread_id or self._new_thread_id()
+        resolved_session_id = session_id or self._new_session_id(user_id=user_id)
+        resolved_thread_id = thread_id or self._thread_id_for_session(resolved_session_id)
         resolved_session_id = session_id or self._new_session_id()
         self._session_threads[resolved_session_id] = resolved_thread_id
         return resolved_session_id, resolved_thread_id
 
     @staticmethod
-    def _new_session_id() -> str:
-        return f"session_{uuid4().hex[:12]}"
+    def _new_session_id(*, user_id: str | None = None) -> str:
+        suffix = uuid4().hex[:12]
+        if not user_id:
+            return f"session_{suffix}"
+        return f"session_{user_id.replace(':', '_')}_{suffix}"
 
     @staticmethod
-    def _new_thread_id() -> str:
-        return f"thread_{uuid4().hex[:12]}"
+    def _thread_id_for_session(session_id: str) -> str:
+        return f"thread_{uuid5(NAMESPACE_URL, session_id).hex[:12]}"
+
+    async def _ensure_graph(self) -> SupportsAsyncInvoke:
+        if self._graph is not None:
+            return self._graph
+
+        checkpointer, store = await get_agent_persistence()
+        self._graph = build_graph(
+            {
+                "configurable": {
+                    "__checkpointer": checkpointer,
+                    CONFIG_KEY_STORE: store,
+                }
+            }
+        )
+        return self._graph
 
 
 @lru_cache(maxsize=1)

--- a/whoopdata/agent/graph.py
+++ b/whoopdata/agent/graph.py
@@ -8,12 +8,28 @@ from typing import Any
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
 from langgraph.constants import CONFIG_KEY_CHECKPOINTER
+from .memory_tools import manage_memory, search_memory
 
 from .prompts import SUPERVISOR_SYSTEM_PROMPT
-from .schemas import AgentConfig
+from .schemas import AgentConfig, HealthContextSchema
 from .specialists import build_specialist_tools
 from .tools import python_repl_tool, get_protein_recommendation_tool
 from . import settings
+
+CONFIG_KEY_STORE = "__store"
+
+
+def _dedupe_tools_by_name(tools: list[Any]) -> list[Any]:
+    seen: set[str] = set()
+    deduped: list[Any] = []
+    for tool in tools:
+        name = getattr(tool, "name", None)
+        if name and name in seen:
+            continue
+        if name:
+            seen.add(name)
+        deduped.append(tool)
+    return deduped
 
 def _resolve_checkpointer(
     config: dict[str, Any] | None,
@@ -25,7 +41,18 @@ def _resolve_checkpointer(
         return None
     return configurable.get(CONFIG_KEY_CHECKPOINTER)
 
-def _create_graph(*, checkpointer: Any | None = None):
+def _resolve_store(
+    config: dict[str, Any] | None,
+) -> Any | None:
+    if not isinstance(config, dict):
+        return None
+    configurable = config.get("configurable")
+    if not isinstance(configurable, dict):
+        return None
+    return configurable.get(CONFIG_KEY_STORE)
+
+
+def _create_graph(*, checkpointer: Any | None = None, store: Any | None = None):
     """Build the compiled health data agent graph.
 
     Creates a supervisor agent (via create_agent) that delegates to
@@ -39,7 +66,12 @@ def _create_graph(*, checkpointer: Any | None = None):
     specialist_tools = build_specialist_tools()
 
     # Supervisor gets specialist tools + python REPL + protein tool for direct use
-    all_tools = specialist_tools + [python_repl_tool, get_protein_recommendation_tool]
+    all_tools = _dedupe_tools_by_name(specialist_tools + [
+        python_repl_tool,
+        get_protein_recommendation_tool,
+        search_memory,
+        manage_memory,
+    ])
 
     # Create the supervisor agent
     # create_agent returns a compiled LangGraph graph that handles
@@ -49,9 +81,12 @@ def _create_graph(*, checkpointer: Any | None = None):
         "tools": all_tools,
         "system_prompt": SUPERVISOR_SYSTEM_PROMPT,
         "name": "health_coach",
+        "context_schema": HealthContextSchema,
     }
     if checkpointer is not None:
         graph_kwargs["checkpointer"] = checkpointer
+    if store is not None:
+        graph_kwargs["store"] = store
 
     graph = create_agent(
         **graph_kwargs,
@@ -70,7 +105,10 @@ def build_graph(config: dict[str, Any] | None = None):
     Returns:
         Compiled LangGraph graph ready for .invoke() / .ainvoke()
     """
-    return _create_graph(checkpointer=_resolve_checkpointer(config))
+    return _create_graph(
+        checkpointer=_resolve_checkpointer(config),
+        store=_resolve_store(config),
+    )
 
 
 async def run_agent(message: str, thread_id: str = "default") -> dict:

--- a/whoopdata/agent/memory_tools.py
+++ b/whoopdata/agent/memory_tools.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Literal
+from uuid import uuid4
+
+from langchain.tools import ToolRuntime, tool
+
+from whoopdata.agent.schemas import HealthContextSchema
+
+MEMORY_CATEGORIES = ("profile", "goal", "constraint", "commitment", "observation")
+
+
+def _validate_category(category: str) -> str:
+    normalized = category.strip().lower()
+    if normalized not in MEMORY_CATEGORIES:
+        valid = ", ".join(MEMORY_CATEGORIES)
+        raise ValueError(f"Invalid memory category '{category}'. Valid categories: {valid}")
+    return normalized
+
+
+def _namespace_for(user_id: str, category: str) -> tuple[str, str, str]:
+    return ("memory", user_id, category)
+
+
+@tool
+async def search_memory(
+    query: str,
+    category: str | None = None,
+    limit: int = 5,
+    runtime: ToolRuntime[HealthContextSchema] = None,
+) -> str:
+    """Search durable user memory when personalized coaching context is relevant."""
+    if runtime is None or runtime.store is None:
+        return "Memory store is unavailable."
+
+    user_id = runtime.context.user_id
+    categories = [_validate_category(category)] if category else list(MEMORY_CATEGORIES)
+    results: list[str] = []
+    seen_ids: set[str] = set()
+
+    for resolved_category in categories:
+        items = await runtime.store.asearch(
+            _namespace_for(user_id, resolved_category),
+            query=query,
+            limit=max(1, limit),
+        )
+        for item in items:
+            if item.key in seen_ids:
+                continue
+            seen_ids.add(item.key)
+            value = item.value or {}
+            content = value.get("content", "")
+            if not content:
+                continue
+            results.append(f"[{resolved_category}] id={item.key}: {content}")
+            if len(results) >= limit:
+                break
+        if len(results) >= limit:
+            break
+
+    if not results:
+        return "No relevant memories found."
+
+    return "\n".join(results)
+
+
+@tool
+async def manage_memory(
+    action: Literal["create", "update", "delete"],
+    category: Literal["profile", "goal", "constraint", "commitment", "observation"],
+    content: str | None = None,
+    memory_id: str | None = None,
+    runtime: ToolRuntime[HealthContextSchema] = None,
+) -> str:
+    """Create, update, or delete durable coaching memory when the user shares stable information."""
+    if runtime is None or runtime.store is None:
+        return "Memory store is unavailable."
+
+    resolved_category = _validate_category(category)
+    user_id = runtime.context.user_id
+    namespace = _namespace_for(user_id, resolved_category)
+    key = memory_id or ("profile" if resolved_category == "profile" else str(uuid4()))
+
+    if action == "delete":
+        delete_method = getattr(runtime.store, "adelete", None)
+        if delete_method is not None:
+            await delete_method(namespace, key)
+        else:
+            await runtime.store.aput(namespace, key, {"deleted": True})
+        return f"Deleted memory '{key}' in category '{resolved_category}'."
+
+    if not content:
+        return "content is required for create and update actions."
+
+    payload = {
+        "category": resolved_category,
+        "content": content,
+        "surface": runtime.context.surface,
+        "user_id": user_id,
+    }
+    await runtime.store.aput(namespace, key, payload)
+    return f"{action.title()}d memory '{key}' in category '{resolved_category}'."

--- a/whoopdata/agent/persistence.py
+++ b/whoopdata/agent/persistence.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import AbstractAsyncContextManager
+from typing import Any
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.store.memory import InMemoryStore
+
+from whoopdata.agent import settings
+
+try:
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from langgraph.store.postgres.aio import AsyncPostgresStore
+except Exception:  # pragma: no cover - optional dependency in tests/dev
+    AsyncPostgresSaver = None
+    AsyncPostgresStore = None
+
+
+class AgentPersistence:
+    """Shared persistence resources for the agent graph."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._checkpointer: Any | None = None
+        self._store: Any | None = None
+        self._checkpointer_cm: AbstractAsyncContextManager[Any] | None = None
+        self._store_cm: AbstractAsyncContextManager[Any] | None = None
+
+    async def get_resources(self) -> tuple[Any, Any]:
+        if self._checkpointer is not None and self._store is not None:
+            return self._checkpointer, self._store
+
+        async with self._lock:
+            if self._checkpointer is not None and self._store is not None:
+                return self._checkpointer, self._store
+
+            if settings.AGENT_POSTGRES_URL and AsyncPostgresSaver and AsyncPostgresStore:
+                self._checkpointer_cm = AsyncPostgresSaver.from_conn_string(
+                    settings.AGENT_POSTGRES_URL
+                )
+                self._store_cm = AsyncPostgresStore.from_conn_string(settings.AGENT_POSTGRES_URL)
+                self._checkpointer = await self._checkpointer_cm.__aenter__()
+                self._store = await self._store_cm.__aenter__()
+                if settings.AGENT_PERSISTENCE_AUTO_SETUP:
+                    await self._checkpointer.setup()
+                    await self._store.setup()
+            else:
+                self._checkpointer = InMemorySaver()
+                self._store = InMemoryStore()
+
+            return self._checkpointer, self._store
+
+
+_PERSISTENCE = AgentPersistence()
+
+
+async def get_agent_persistence() -> tuple[Any, Any]:
+    return await _PERSISTENCE.get_resources()

--- a/whoopdata/agent/public_response.py
+++ b/whoopdata/agent/public_response.py
@@ -18,6 +18,7 @@ class AgentArtifact(BaseModel):
 class AgentConversationCreateRequest(BaseModel):
     session_id: str | None = None
     thread_id: str | None = None
+    user_id: str | None = None
 
 
 class AgentConversationHandle(BaseModel):
@@ -34,6 +35,7 @@ class AgentMessageRequest(BaseModel):
     message: str = Field(min_length=1)
     thread_id: str | None = None
     session_id: str | None = None
+    user_id: str | None = None
 
 
 class AgentConversationResponse(BaseModel):

--- a/whoopdata/agent/registry.py
+++ b/whoopdata/agent/registry.py
@@ -129,6 +129,7 @@ AGENT_REGISTRY: dict[str, dict] = {
             "get_weight_data",
             "get_workout_data",
             "get_recovery_data",
+            "search_memory",
         ],
     },
     "behaviour_change": {
@@ -144,6 +145,7 @@ AGENT_REGISTRY: dict[str, dict] = {
             "get_recovery_data",
             "get_weight_data",
             "get_workout_data",
+            "search_memory",
         ],
     },
     "nutrition": {

--- a/whoopdata/agent/schemas.py
+++ b/whoopdata/agent/schemas.py
@@ -29,6 +29,7 @@ class HealthContextSchema:
     user_id: str = "default_user"
     health_api_base_url: str = "http://localhost:8000"
     preferred_data_range_days: int = 30
+    surface: str = "api"
 
     def __post_init__(self):
         """Initialize any additional context data."""

--- a/whoopdata/agent/settings.py
+++ b/whoopdata/agent/settings.py
@@ -31,6 +31,10 @@ TFL_KEY_LINES = ["Jubilee", "DLR", "Elizabeth line", "Northern"]  # Lines near S
 # Agent Configuration
 AGENT_TIMEOUT_SECONDS = 30.0
 MAX_ITERATIONS = 10
+AGENT_POSTGRES_URL = os.getenv("AGENT_POSTGRES_URL")
+AGENT_PERSISTENCE_AUTO_SETUP = (
+    os.getenv("AGENT_PERSISTENCE_AUTO_SETUP", "true").strip().lower() == "true"
+)
 
 # Supervisor model (delegates to specialists)
 SUPERVISOR_MODEL = "openai:gpt-4o-mini"

--- a/whoopdata/agent/specialists.py
+++ b/whoopdata/agent/specialists.py
@@ -5,12 +5,17 @@ as tools for the supervisor to call. Each specialist runs in an isolated
 context and returns only its final text response.
 """
 
+from typing import Any
+
 from langchain.agents import create_agent
+from langchain.tools import ToolRuntime
 from langchain_core.tools import StructuredTool
 from langchain_core.messages import AIMessage
+from langgraph.constants import CONFIG_KEY_CHECKPOINTER
 
 from .tools import TOOLS_BY_NAME
 from .registry import AGENT_REGISTRY
+from .schemas import HealthContextSchema
 from . import settings
 
 
@@ -78,10 +83,28 @@ def build_specialist_tools(
 
         # Wrap as a tool — closure captures agent_name, agent, description
         def _make_tool(name: str, desc: str, compiled_agent):
-            async def specialist_fn(query: str) -> str:
+            async def specialist_fn(
+                query: str,
+                runtime: ToolRuntime[HealthContextSchema] = None,
+            ) -> str:
                 """Delegate a query to a specialist subagent."""
+                invoke_kwargs: dict[str, Any] = {}
+                if runtime is not None:
+                    runtime_config = getattr(runtime, "config", None)
+                    configurable: dict[str, Any] = {}
+                    if isinstance(runtime_config, dict):
+                        configurable.update(runtime_config.get("configurable", {}))
+                    if getattr(runtime, "store", None) is not None:
+                        configurable["__store"] = runtime.store
+                    if getattr(runtime, "checkpointer", None) is not None:
+                        configurable[CONFIG_KEY_CHECKPOINTER] = runtime.checkpointer
+                    if configurable:
+                        invoke_kwargs["config"] = {"configurable": configurable}
+                    if getattr(runtime, "context", None) is not None:
+                        invoke_kwargs["context"] = runtime.context
                 result = await compiled_agent.ainvoke(
-                    {"messages": [{"role": "user", "content": query}]}
+                    {"messages": [{"role": "user", "content": query}]},
+                    **invoke_kwargs,
                 )
                 return _extract_final_response(result)
 

--- a/whoopdata/api/agent_routes.py
+++ b/whoopdata/api/agent_routes.py
@@ -22,6 +22,7 @@ async def create_conversation(
     return conversation_service.start_conversation(
         session_id=request.session_id,
         thread_id=request.thread_id,
+        user_id=request.user_id,
     )
 
 
@@ -35,6 +36,8 @@ async def send_message(
             message=payload.message,
             session_id=payload.session_id,
             thread_id=payload.thread_id,
+            user_id=payload.user_id,
+            surface="api",
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Error processing agent message: {str(exc)}")

--- a/whoopdata/telegram_bot.py
+++ b/whoopdata/telegram_bot.py
@@ -110,13 +110,21 @@ class TelegramConversationGateway:
     ) -> list[OutboundTelegramMessage]:
         if not self.is_authorized(user_id=user_id, chat_id=chat_id, chat_type=chat_type):
             return []
-
+        binding = self._bindings_by_chat.setdefault(
+            chat_id,
+            ConversationBinding(
+                session_id=f"telegram-chat-{chat_id}",
+                thread_id=f"telegram-thread-{chat_id}",
+            ),
+        )
         binding = self._bindings_by_chat.setdefault(chat_id, ConversationBinding())
         response = await self._conversation_service.send_message(
             message=text,
             session_id=binding.session_id,
             thread_id=binding.thread_id,
             image_b64=image_b64,
+            user_id=f"telegram:{user_id}",
+            surface="telegram",
         )
         binding.session_id = response.session_id
         binding.thread_id = response.thread_id


### PR DESCRIPTION
## Summary
- add durable shared agent memory with Postgres-backed persistence support
- wire memory-aware behavior into the supervisor and specialist flows
- add Telegram photo handling and local development helper make targets

## Validation
- `uv run pytest tests/test_agent_memory_tools.py`
- `uv run pytest tests/test_agent_conversation_service.py tests/test_agent_routes.py tests/test_chat_app_boundary.py tests/test_telegram_bot_boundary.py`
- `python -m py_compile whoopdata/agent/specialists.py whoopdata/agent/graph.py whoopdata/agent/registry.py whoopdata/telegram_bot.py`

Co-Authored-By: Oz <oz-agent@warp.dev>
