### PR TITLE
feat: improve telegram continuity and automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the WHOOP Data Platform will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.3.0] - 2026-03-23
+
+### Added
+
+- Added a proactive Telegram push flow, API endpoint, and helper scripts so the morning summary and manual smoke tests can send agent responses into the same shared conversation thread the Telegram bot uses.
+- Added persistent `launchd` service definitions and Make helpers for the API server, Telegram bot, and scheduled morning summary job on macOS.
+
+### Changed
+
+- Fixed Telegram conversation continuity so repeated messages in the same private chat reuse the canonical session/thread binding and correctly load LangGraph checkpoint state from the configured persistent checkpointer.
+- Updated the Telegram bot transport and related tests to cover stable chat-bound session/thread reuse and the shared persistence path used by runtime services.
 ## [3.2.0] - 2026-03-22
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev sync run server etl chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify
+.PHONY: help install dev sync run server etl chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify schedule-up schedule-down schedule-test morning-now services-up services-down services-test
 
 # Default target
 help:
@@ -24,6 +24,13 @@ help:
 	@echo "  make postgres-up - Start local Docker Postgres for shared agent memory"
 	@echo "  make postgres-down - Stop local Docker Postgres container"
 	@echo "  make postgres-logs - Tail local Docker Postgres logs"
+	@echo "  make services-up   - Install persistent launchd services for API + Telegram bot + morning job"
+	@echo "  make services-down - Uninstall persistent launchd services"
+	@echo "  make services-test - Check persistent service status"
+	@echo "  make schedule-up   - Install launchd schedule (daily morning ETL + push)"
+	@echo "  make schedule-down - Uninstall launchd schedule"
+	@echo "  make schedule-test - Check if the schedule is loaded"
+	@echo "  make morning-now   - Run the morning ETL + push immediately"
 	@echo ""
 	@echo "Development:"
 	@echo "  make test        - Run tests with pytest"
@@ -58,6 +65,7 @@ run:
 
 server:
 	@echo "🌐 Starting FastAPI server..."
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.server.plist 2>/dev/null || true
 	uv run uvicorn main:app --host localhost --port 8000 --reload
 
 etl:
@@ -88,6 +96,7 @@ langgraph-dev:
 
 dev-all:
 	@echo "🚀 Starting FastAPI server + LangGraph dev server..."
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.server.plist 2>/dev/null || true
 	uv run uvicorn main:app --host localhost --port 8000 --reload &
 	@sleep 3
 	@echo "📍 FastAPI: http://0.0.0.0:8000"
@@ -97,6 +106,8 @@ dev-all:
 
 dev-full:
 	@echo "🚀 Starting FastAPI server + Telegram bot + LangGraph dev server..."
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.server.plist 2>/dev/null || true
+	@echo "  (paused launchd server for dev mode)"
 	uv run uvicorn main:app --host localhost --port 8000 --reload &
 	@echo $$! > .dev-full-server.pid
 	@sleep 3
@@ -125,6 +136,10 @@ dev-full-stop:
 	@pkill -f 'uvicorn main:app --host localhost --port 8000 --reload' 2>/dev/null || true
 	@pkill -f 'langgraph dev --allow-blocking' 2>/dev/null || true
 	@echo "✅ Local dev processes stopped"
+	@if [ -f ~/Library/LaunchAgents/com.whoopdata.server.plist ]; then \
+		launchctl load ~/Library/LaunchAgents/com.whoopdata.server.plist 2>/dev/null || true; \
+		echo "  (resumed launchd server)"; \
+	fi
 
 postgres-up:
 	@echo "🐘 Ensuring local Postgres container is running..."
@@ -146,6 +161,42 @@ postgres-down:
 
 postgres-logs:
 	@docker logs -f whoop-agent-postgres
+
+schedule-up:
+	@echo "📅 Installing launchd services..."
+	@mkdir -p logs
+	@cp schedules/com.whoopdata.server.plist ~/Library/LaunchAgents/com.whoopdata.server.plist
+	@cp schedules/com.whoopdata.telegram.plist ~/Library/LaunchAgents/com.whoopdata.telegram.plist
+	@cp schedules/com.whoopdata.morning.plist ~/Library/LaunchAgents/com.whoopdata.morning.plist
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.server.plist
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.telegram.plist
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.morning.plist
+	@echo "✅ Installed: persistent FastAPI server + Telegram bot + daily 07:30 morning job"
+	@echo "   Check with: make schedule-test"
+
+schedule-down:
+	@echo "🛑 Removing launchd services..."
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.server.plist 2>/dev/null || true
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.telegram.plist 2>/dev/null || true
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.morning.plist 2>/dev/null || true
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.server.plist
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.telegram.plist
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.morning.plist
+	@echo "✅ All whoopdata services removed"
+
+schedule-test:
+	@echo "📋 Checking schedule status..."
+	@launchctl list | grep whoopdata || echo "No whoopdata schedules loaded"
+
+services-up: schedule-up
+
+services-down: schedule-down
+
+services-test: schedule-test
+
+morning-now:
+	@echo "☀️ Running morning ETL + push now..."
+	uv run python scripts/scheduled_morning.py
 
 # Development targets
 test:

--- a/README.md
+++ b/README.md
@@ -274,11 +274,25 @@ make telegram-bot
 
 `make dev-all` starts FastAPI and LangGraph dev tooling, but it does not start the Telegram bot.
 
+For an always-on local setup on macOS, use the persistent service helpers instead:
+
+```bash
+make services-up
+make services-test
+```
+
+That installs `launchd` jobs for the API server, Telegram bot, and the scheduled morning summary push. Remove them with:
+
+```bash
+make services-down
+```
+
 ### Current Telegram behavior
 
 - Supports `/start` and `/whoami`
 - Supports normal text chat with the shared health-data agent
 - Reuses conversation context per Telegram chat
+- Supports proactive pushes into the same shared Telegram conversation thread via `/api/v1/agent/telegram/push`
 - Rejects non-private chats
 - Uses Telegram-only HTML formatting for better rendering without changing Studio/API output
 - Sends agent-generated image artifacts back to Telegram when available
@@ -291,6 +305,20 @@ Current limitations:
 - Voice replies use OpenAI TTS which has a ~2000 token input limit; very long responses fall back to text only
 
 The Telegram adapter can silently ignore unauthorized users once the allowlists are set. Rotate any token that was ever pasted into chat, logs, or source control before relying on the bot.
+
+### Proactive Telegram smoke test
+
+You can send yourself a proactive Telegram message that goes through the shared conversation service:
+
+```bash
+uv run -m scripts.telegram_hello --prompt "set me up for the day"
+```
+
+Or route the same flow through the running API server:
+
+```bash
+uv run -m scripts.telegram_hello --api --prompt "set me up for the day"
+```
 
 ## Rollout Verification Checklist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "3.2.0"
+version = "3.3.0"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schedules/com.whoopdata.morning.plist
+++ b/schedules/com.whoopdata.morning.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.whoopdata.morning</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/home/.local/bin/uv</string>
+        <string>run</string>
+        <string>--project</string>
+        <string>/Users/home/Documents/Projects/whoop-data</string>
+        <string>python</string>
+        <string>/Users/home/Documents/Projects/whoop-data/scripts/scheduled_morning.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/home/Documents/Projects/whoop-data</string>
+
+    <!-- 07:30 UTC daily. launchd uses local time, so adjust if your
+         Mac Mini is not set to UTC. For BST (UTC+1) this would be 08:30. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>7</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <!-- Logs for debugging -->
+    <key>StandardOutPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/morning-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/morning-stderr.log</string>
+
+    <!-- Environment variables (launchd doesn't inherit your shell env) -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/home</string>
+    </dict>
+</dict>
+</plist>

--- a/schedules/com.whoopdata.server.plist
+++ b/schedules/com.whoopdata.server.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.whoopdata.server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/home/.local/bin/uv</string>
+        <string>run</string>
+        <string>--project</string>
+        <string>/Users/home/Documents/Projects/whoop-data</string>
+        <string>uvicorn</string>
+        <string>main:app</string>
+        <string>--host</string>
+        <string>localhost</string>
+        <string>--port</string>
+        <string>8000</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/home/Documents/Projects/whoop-data</string>
+
+    <!-- Keep it running: restart on crash, start at boot -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Logs -->
+    <key>StandardOutPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/server-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/server-stderr.log</string>
+
+    <!-- Environment -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/home</string>
+    </dict>
+</dict>
+</plist>

--- a/schedules/com.whoopdata.telegram.plist
+++ b/schedules/com.whoopdata.telegram.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.whoopdata.telegram</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/home/.local/bin/uv</string>
+        <string>run</string>
+        <string>--project</string>
+        <string>/Users/home/Documents/Projects/whoop-data</string>
+        <string>whoop-telegram-bot</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/home/Documents/Projects/whoop-data</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/telegram-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/telegram-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/home</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/scheduled_morning.py
+++ b/scripts/scheduled_morning.py
@@ -1,0 +1,103 @@
+"""Scheduled morning job: incremental ETL then proactive Telegram push.
+
+Designed to be invoked by launchd (or cron). Runs two steps:
+1. Incremental ETL — pull latest WHOOP + Withings data
+2. Morning push  — send a health summary to Telegram via the agent
+
+Each step is independent: if the ETL fails, the push still fires
+(with slightly stale data).  Logs go to stdout/stderr for launchd
+to capture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+
+# Ensure the project root is on the path so "whoopdata" is importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+os.chdir(PROJECT_ROOT)
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("scheduled_morning")
+
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+MORNING_PROMPT = (
+    "Good morning! Please give me a concise morning health briefing based on "
+    "my latest WHOOP and Withings data. Include recovery score, sleep quality, "
+    "and any notable trends or recommendations for today."
+)
+
+
+def run_etl() -> bool:
+    """Run incremental ETL. Returns True on success."""
+    logger.info("Starting incremental ETL...")
+    try:
+        from whoopdata.database.database import engine
+        from whoopdata.models.models import Base
+
+        Base.metadata.create_all(bind=engine)
+
+        from whoopdata.etl import run_complete_etl
+
+        run_complete_etl(incremental=True)
+        logger.info("ETL completed successfully")
+        return True
+    except Exception:
+        logger.error("ETL failed:\n%s", traceback.format_exc())
+        return False
+
+
+async def run_morning_push() -> bool:
+    """Push morning summary to Telegram. Returns True on success."""
+    if not TELEGRAM_CHAT_ID:
+        logger.error("No TELEGRAM_ALLOWED_CHAT_IDS set — skipping push")
+        return False
+
+    logger.info("Sending morning summary to chat_id=%s", TELEGRAM_CHAT_ID)
+    try:
+        from whoopdata.telegram_push import push_to_telegram
+
+        result = await push_to_telegram(
+            chat_id=int(TELEGRAM_CHAT_ID),
+            prompt=MORNING_PROMPT,
+        )
+        logger.info(
+            "Morning push sent (message_id=%s): %s",
+            result.telegram_message_id,
+            result.assistant_message[:120],
+        )
+        return True
+    except Exception:
+        logger.error("Morning push failed:\n%s", traceback.format_exc())
+        return False
+
+
+def main() -> int:
+    etl_ok = run_etl()
+    push_ok = asyncio.run(run_morning_push())
+
+    if etl_ok and push_ok:
+        logger.info("Scheduled morning job completed successfully")
+        return 0
+    elif push_ok:
+        logger.warning("Morning push succeeded but ETL had errors")
+        return 0  # Still exit 0 — the user got their summary
+    else:
+        logger.error("Morning push failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/telegram_hello.py
+++ b/scripts/telegram_hello.py
@@ -1,0 +1,69 @@
+"""Smoke test: push a proactive agent message to Telegram.
+
+Usage:
+    # Standalone — runs the full agent, needs Postgres up:
+    uv run python scripts/telegram_hello.py
+
+    # Via API — hit the running FastAPI server instead:
+    uv run python scripts/telegram_hello.py --api
+
+    # Custom prompt:
+    uv run python scripts/telegram_hello.py --prompt "How did I sleep last night?"
+"""
+
+import argparse
+import asyncio
+import os
+
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+DEFAULT_PROMPT = "Give me a brief morning health summary based on my latest data."
+API_BASE = "http://localhost:8000"
+
+
+async def push_standalone(chat_id: int, prompt: str) -> None:
+    """Send directly through the agent (no FastAPI needed, but Postgres must be up)."""
+    from whoopdata.telegram_push import push_to_telegram
+
+    result = await push_to_telegram(chat_id=chat_id, prompt=prompt)
+    print(f"\u2705 Pushed to chat_id={chat_id}, message_id={result.telegram_message_id}")
+    print(f"Agent said: {result.assistant_message[:200]}")
+
+
+async def push_via_api(chat_id: int, prompt: str) -> None:
+    """Hit the running FastAPI endpoint (all servers must be up via make dev-full)."""
+    async with httpx.AsyncClient(timeout=120) as client:
+        resp = await client.post(
+            f"{API_BASE}/api/v1/agent/telegram/push",
+            json={"chat_id": chat_id, "prompt": prompt},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    print(f"\u2705 Pushed via API to chat_id={chat_id}, message_id={data.get('telegram_message_id')}")
+    print(f"Agent said: {data['assistant_message'][:200]}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Push a proactive agent message to Telegram")
+    parser.add_argument("--api", action="store_true", help="Use the running FastAPI server")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Prompt for the agent")
+    parser.add_argument("--chat-id", default=TELEGRAM_CHAT_ID, help="Telegram chat ID")
+    args = parser.parse_args()
+
+    if not args.chat_id:
+        raise RuntimeError("No chat ID — set TELEGRAM_ALLOWED_CHAT_IDS in .env or pass --chat-id")
+
+    chat_id = int(args.chat_id)
+
+    if args.api:
+        asyncio.run(push_via_api(chat_id, args.prompt))
+    else:
+        asyncio.run(push_standalone(chat_id, args.prompt))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_conversation_service.py
+++ b/tests/test_agent_conversation_service.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import asyncio
 
 from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.constants import CONFIG_KEY_CHECKPOINTER
 
 from whoopdata.agent.conversation_service import ConversationService
+from whoopdata.agent.graph import CONFIG_KEY_STORE
 
 
 class FakeGraph:
     def __init__(self, result: dict | None = None) -> None:
         self.calls: list[tuple[dict, dict, object | None]] = []
         self._result = result or {"messages": [AIMessage(content="Default response.")]}
+
     async def ainvoke(self, input: dict, config: dict, *, context=None) -> dict:
         self.calls.append((input, config, context))
         return self._result
@@ -115,3 +118,34 @@ def test_send_message_isolates_distinct_conversations_by_thread():
     assert first_response.session_id != second_response.session_id
     assert first_response.thread_id != second_response.thread_id
     assert graph.calls[0][1] != graph.calls[1][1]
+
+
+def test_ensure_graph_passes_checkpointer_and_store_with_langgraph_keys(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_get_agent_persistence():
+        return "checkpointer", "store"
+
+    def _fake_build_graph(config):
+        captured["config"] = config
+        return FakeGraph()
+
+    monkeypatch.setattr(
+        "whoopdata.agent.conversation_service.get_agent_persistence",
+        _fake_get_agent_persistence,
+    )
+    monkeypatch.setattr(
+        "whoopdata.agent.conversation_service.build_graph",
+        _fake_build_graph,
+    )
+
+    service = ConversationService()
+
+    asyncio.run(service._ensure_graph())
+
+    assert captured["config"] == {
+        "configurable": {
+            CONFIG_KEY_CHECKPOINTER: "checkpointer",
+            CONFIG_KEY_STORE: "store",
+        }
+    }

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"

--- a/whoopdata/agent/conversation_service.py
+++ b/whoopdata/agent/conversation_service.py
@@ -5,6 +5,7 @@ from typing import Any, Protocol
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from langchain_core.messages import HumanMessage
+from langgraph.constants import CONFIG_KEY_CHECKPOINTER
 
 from whoopdata.agent import settings
 from whoopdata.agent.graph import CONFIG_KEY_STORE, build_graph
@@ -127,7 +128,6 @@ class ConversationService:
             return session_id, self._session_threads[session_id]
         resolved_session_id = session_id or self._new_session_id(user_id=user_id)
         resolved_thread_id = thread_id or self._thread_id_for_session(resolved_session_id)
-        resolved_session_id = session_id or self._new_session_id()
         self._session_threads[resolved_session_id] = resolved_thread_id
         return resolved_session_id, resolved_thread_id
 
@@ -150,7 +150,7 @@ class ConversationService:
         self._graph = build_graph(
             {
                 "configurable": {
-                    "__checkpointer": checkpointer,
+                    CONFIG_KEY_CHECKPOINTER: checkpointer,
                     CONFIG_KEY_STORE: store,
                 }
             }

--- a/whoopdata/api/agent_routes.py
+++ b/whoopdata/api/agent_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel, Field
 
 from whoopdata.agent.conversation_service import ConversationService, get_conversation_service
 from whoopdata.agent.public_response import (
@@ -41,3 +42,43 @@ async def send_message(
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Error processing agent message: {str(exc)}")
+
+
+class TelegramPushRequest(BaseModel):
+    chat_id: int
+    prompt: str = Field(
+        default="Give me a brief morning health summary based on my latest data.",
+        description="Internal prompt sent to the agent. The user only sees the agent's response.",
+    )
+
+
+class TelegramPushResponse(BaseModel):
+    assistant_message: str
+    telegram_message_id: int | None = None
+
+
+@router.post("/telegram/push", response_model=TelegramPushResponse)
+async def telegram_push(
+    payload: TelegramPushRequest,
+    conversation_service: ConversationService = Depends(get_conversation_service),
+):
+    """Push a proactive agent message to a Telegram chat.
+
+    The prompt is routed through the shared ConversationService so the
+    exchange is checkpointed in the same thread the Telegram bot uses.
+    When the user replies in Telegram, the conversation continues seamlessly.
+    """
+    from whoopdata.telegram_push import push_to_telegram
+
+    try:
+        result = await push_to_telegram(
+            chat_id=payload.chat_id,
+            prompt=payload.prompt,
+            conversation_service=conversation_service,
+        )
+        return TelegramPushResponse(
+            assistant_message=result.assistant_message,
+            telegram_message_id=result.telegram_message_id,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Telegram push failed: {str(exc)}")

--- a/whoopdata/telegram_bot.py
+++ b/whoopdata/telegram_bot.py
@@ -49,6 +49,16 @@ class OutboundTelegramMessage:
     parse_mode: str | None = None
 
 
+def thread_id_for_chat(chat_id: int) -> str:
+    """Canonical thread ID for a Telegram chat. Used by both the bot and proactive push."""
+    return f"telegram-thread-{chat_id}"
+
+
+def session_id_for_chat(chat_id: int) -> str:
+    """Canonical session ID for a Telegram chat. Used by both the bot and proactive push."""
+    return f"telegram-chat-{chat_id}"
+
+
 @dataclass
 class ConversationBinding:
     session_id: str | None = None
@@ -113,11 +123,10 @@ class TelegramConversationGateway:
         binding = self._bindings_by_chat.setdefault(
             chat_id,
             ConversationBinding(
-                session_id=f"telegram-chat-{chat_id}",
-                thread_id=f"telegram-thread-{chat_id}",
+                session_id=session_id_for_chat(chat_id),
+                thread_id=thread_id_for_chat(chat_id),
             ),
         )
-        binding = self._bindings_by_chat.setdefault(chat_id, ConversationBinding())
         response = await self._conversation_service.send_message(
             message=text,
             session_id=binding.session_id,
@@ -190,7 +199,7 @@ class TelegramConversationGateway:
         if assistant_message:
             messages.append(
                 OutboundTelegramMessage(
-                    text=_format_text_for_telegram_html(assistant_message),
+                    text=format_text_for_telegram_html(assistant_message),
                     parse_mode=ParseMode.HTML,
                 )
             )
@@ -274,7 +283,7 @@ def _strip_html_tags(text: str) -> str:
     return re.sub(r"<[^>]+>", "", text)
 
 
-def _format_text_for_telegram_html(text: str) -> str:
+def format_text_for_telegram_html(text: str) -> str:
     escaped = html.escape(text)
     escaped = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", escaped)
     escaped = re.sub(r"\*\*([^\n*][^*]*?)\*\*", r"<b>\1</b>", escaped)

--- a/whoopdata/telegram_push.py
+++ b/whoopdata/telegram_push.py
@@ -1,0 +1,105 @@
+"""Proactive Telegram push — sends agent-generated messages to Telegram.
+
+The message goes through ConversationService so it lands in the same
+checkpointed thread the Telegram bot uses.  When the user replies in
+Telegram, the bot handler picks up the same thread from Postgres and
+the conversation continues seamlessly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+from whoopdata.agent.conversation_service import ConversationService, get_conversation_service
+from whoopdata.telegram_bot import (
+    format_text_for_telegram_html,
+    session_id_for_chat,
+    thread_id_for_chat,
+)
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+
+
+@dataclass
+class PushResult:
+    assistant_message: str
+    telegram_message_id: int | None = None
+
+
+async def push_to_telegram(
+    *,
+    chat_id: int,
+    prompt: str,
+    conversation_service: ConversationService | None = None,
+    bot_token: str | None = None,
+) -> PushResult:
+    """Send a proactive agent message to a Telegram chat.
+
+    1. Routes ``prompt`` through the shared ConversationService so the
+       exchange is checkpointed in the same thread the Telegram bot uses.
+    2. Delivers the agent's response to the Telegram chat via Bot API.
+
+    Args:
+        chat_id: Telegram chat to push to.
+        prompt: Internal prompt that triggers the agent (the user won't
+                see this — only the agent's response is sent).
+        conversation_service: Optional; defaults to the singleton.
+        bot_token: Optional; defaults to TELEGRAM_BOT_TOKEN env var.
+
+    Returns:
+        PushResult with the assistant message and Telegram message ID.
+    """
+    svc = conversation_service or get_conversation_service()
+    token = bot_token or TELEGRAM_BOT_TOKEN
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN is required for proactive push")
+
+    # Send through the conversation service on the same thread the bot uses
+    response = await svc.send_message(
+        message=prompt,
+        session_id=session_id_for_chat(chat_id),
+        thread_id=thread_id_for_chat(chat_id),
+        user_id=f"telegram:{chat_id}",
+        surface="telegram",
+    )
+
+    # Deliver the agent's response to Telegram
+    from telegram import Bot
+    from telegram.constants import ParseMode
+
+    bot = Bot(token=token)
+    formatted = format_text_for_telegram_html(response.assistant_message)
+    try:
+        msg = await bot.send_message(
+            chat_id=chat_id,
+            text=formatted,
+            parse_mode=ParseMode.HTML,
+        )
+        telegram_message_id = msg.message_id
+    except Exception:
+        # Fall back to plain text if HTML formatting causes issues
+        logger.warning("HTML send failed, retrying as plain text")
+        msg = await bot.send_message(
+            chat_id=chat_id,
+            text=response.assistant_message,
+        )
+        telegram_message_id = msg.message_id
+
+    logger.info(
+        "Proactive push sent to chat_id=%s, message_id=%s",
+        chat_id,
+        telegram_message_id,
+    )
+
+    return PushResult(
+        assistant_message=response.assistant_message,
+        telegram_message_id=telegram_message_id,
+    )


### PR DESCRIPTION
## Summary
- add persistent launchd-managed API, Telegram, and morning-summary workflows plus proactive Telegram push helpers
- fix Telegram conversation continuity by preserving chat-bound session/thread reuse and wiring the LangGraph checkpointer correctly
- bump the package to 3.3.0 and update README/changelog guidance for services and Telegram smoke tests

## Validation
- uv run pytest tests/test_agent_conversation_service.py tests/test_telegram_bot_boundary.py
- plutil -lint schedules/com.whoopdata.server.plist schedules/com.whoopdata.telegram.plist schedules/com.whoopdata.morning.plist
- uv run -m scripts.telegram_hello
- uv run -m scripts.telegram_hello --prompt "set me up for the day"

Co-Authored-By: Oz <oz-agent@warp.dev>