### PR TITLE
feat: automate headless whoop etl refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the WHOOP Data Platform will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.4.0] - 2026-03-23
+
+### Added
+
+- Added a recurring macOS `launchd` ETL job, dedicated Make targets, and append-only ETL audit logging so headless health-data refresh runs can be scheduled and audited cleanly.
+- Added focused regression coverage for WHOOP offline-scope auth, token persistence, and scheduled ETL audit-log output.
+
+### Changed
+
+- Updated WHOOP authentication flows to request the `offline` scope and persist token expiry metadata, enabling one-time re-authorization followed by headless token refresh on subsequent ETL runs.
 ## [3.3.0] - 2026-03-23
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev sync run server etl chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify schedule-up schedule-down schedule-test morning-now services-up services-down services-test
+.PHONY: help install dev sync run server etl etl-full etl-now etl-up etl-down etl-test chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify schedule-up schedule-down schedule-test morning-now services-up services-down services-test
 
 # Default target
 help:
@@ -24,9 +24,13 @@ help:
 	@echo "  make postgres-up - Start local Docker Postgres for shared agent memory"
 	@echo "  make postgres-down - Stop local Docker Postgres container"
 	@echo "  make postgres-logs - Tail local Docker Postgres logs"
-	@echo "  make services-up   - Install persistent launchd services for API + Telegram bot + morning job"
+	@echo "  make services-up   - Install persistent launchd services for API + Telegram bot + recurring ETL + morning job"
 	@echo "  make services-down - Uninstall persistent launchd services"
 	@echo "  make services-test - Check persistent service status"
+	@echo "  make etl-up        - Install recurring ETL launchd job"
+	@echo "  make etl-down      - Uninstall recurring ETL launchd job"
+	@echo "  make etl-test      - Check recurring ETL launchd job"
+	@echo "  make etl-now       - Run recurring ETL job immediately"
 	@echo "  make schedule-up   - Install launchd schedule (daily morning ETL + push)"
 	@echo "  make schedule-down - Uninstall launchd schedule"
 	@echo "  make schedule-test - Check if the schedule is loaded"
@@ -167,20 +171,24 @@ schedule-up:
 	@mkdir -p logs
 	@cp schedules/com.whoopdata.server.plist ~/Library/LaunchAgents/com.whoopdata.server.plist
 	@cp schedules/com.whoopdata.telegram.plist ~/Library/LaunchAgents/com.whoopdata.telegram.plist
+	@cp schedules/com.whoopdata.etl.plist ~/Library/LaunchAgents/com.whoopdata.etl.plist
 	@cp schedules/com.whoopdata.morning.plist ~/Library/LaunchAgents/com.whoopdata.morning.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.server.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.telegram.plist
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.etl.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.morning.plist
-	@echo "✅ Installed: persistent FastAPI server + Telegram bot + daily 07:30 morning job"
+	@echo "✅ Installed: persistent FastAPI server + Telegram bot + recurring ETL + daily morning job"
 	@echo "   Check with: make schedule-test"
 
 schedule-down:
 	@echo "🛑 Removing launchd services..."
 	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.server.plist 2>/dev/null || true
 	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.telegram.plist 2>/dev/null || true
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.etl.plist 2>/dev/null || true
 	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.morning.plist 2>/dev/null || true
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.server.plist
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.telegram.plist
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.etl.plist
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.morning.plist
 	@echo "✅ All whoopdata services removed"
 
@@ -193,6 +201,27 @@ services-up: schedule-up
 services-down: schedule-down
 
 services-test: schedule-test
+etl-up:
+	@echo "📅 Installing recurring ETL launchd job..."
+	@mkdir -p logs
+	@cp schedules/com.whoopdata.etl.plist ~/Library/LaunchAgents/com.whoopdata.etl.plist
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.etl.plist
+	@echo "✅ Installed recurring ETL job (every 45 minutes)"
+	@echo "   Check with: make etl-test"
+
+etl-down:
+	@echo "🛑 Removing recurring ETL launchd job..."
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.etl.plist 2>/dev/null || true
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.etl.plist
+	@echo "✅ Recurring ETL job removed"
+
+etl-test:
+	@echo "📋 Checking recurring ETL launchd job..."
+	@launchctl list | grep 'com.whoopdata.etl' || echo "Recurring ETL job not loaded"
+
+etl-now:
+	@echo "🔄 Running recurring ETL job now..."
+	@uv run python scripts/scheduled_etl.py
 
 morning-now:
 	@echo "☀️ Running morning ETL + push now..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "3.3.0"
+version = "3.4.0"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schedules/com.whoopdata.etl.plist
+++ b/schedules/com.whoopdata.etl.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.whoopdata.etl</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/home/.local/bin/uv</string>
+        <string>run</string>
+        <string>--project</string>
+        <string>/Users/home/Documents/Projects/whoop-data</string>
+        <string>python</string>
+        <string>/Users/home/Documents/Projects/whoop-data/scripts/scheduled_etl.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/home/Documents/Projects/whoop-data</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>2700</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/etl-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/etl-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/home</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/scheduled_etl.py
+++ b/scripts/scheduled_etl.py
@@ -1,0 +1,123 @@
+"""Recurring ETL job: refresh tokens if needed, then run incremental ETL.
+
+Designed for launchd's StartInterval scheduling. The WHOOP client handles:
+1. Loading the shared token file
+2. Refreshing access tokens when expired and a refresh token exists
+3. Persisting fresh token state back to disk
+
+Running this every 45 minutes keeps the WHOOP token warm and the local data
+store current for the API, Telegram bot, and agent workflows.
+"""
+
+from __future__ import annotations
+import json
+
+import logging
+import os
+import sys
+import time
+import traceback
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+# Ensure the project root is on the path so "whoopdata" is importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+os.chdir(PROJECT_ROOT)
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("scheduled_etl")
+LOGS_DIR = os.path.join(PROJECT_ROOT, "logs")
+AUDIT_LOG_PATH = os.path.join(LOGS_DIR, "etl-audit.log")
+
+
+def _build_audit_entry(
+    *,
+    started_at: float,
+    finished_at: float,
+    status: str,
+    results: dict | None = None,
+    error: str | None = None,
+) -> dict:
+    duration_seconds = round(finished_at - started_at, 3)
+    per_source = {}
+    total_success = 0
+    total_errors = 0
+
+    for source, stats in (results or {}).items():
+        success = int(stats.get("success", 0))
+        errors = int(stats.get("errors", 0))
+        per_source[source] = {"success": success, "errors": errors}
+        total_success += success
+        total_errors += errors
+
+    return {
+        "timestamp": datetime.fromtimestamp(finished_at, tz=timezone.utc).isoformat(),
+        "job": "scheduled_etl",
+        "status": status,
+        "duration_seconds": duration_seconds,
+        "totals": {"success": total_success, "errors": total_errors},
+        "sources": per_source,
+        "error": error,
+    }
+
+
+def _append_audit_entry(entry: dict) -> None:
+    os.makedirs(LOGS_DIR, exist_ok=True)
+    with open(AUDIT_LOG_PATH, "a", encoding="utf-8") as audit_log:
+        audit_log.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def run_etl() -> bool:
+    """Run incremental ETL and return True on success."""
+    logger.info("Starting recurring incremental ETL run")
+    started_at = time.time()
+    try:
+        from whoopdata.database.database import engine
+        from whoopdata.models.models import Base
+
+        Base.metadata.create_all(bind=engine)
+
+        from whoopdata.etl import run_complete_etl
+        results = run_complete_etl(incremental=True)
+        finished_at = time.time()
+        entry = _build_audit_entry(
+            started_at=started_at,
+            finished_at=finished_at,
+            status="success",
+            results=results,
+        )
+        _append_audit_entry(entry)
+        logger.info(
+            "Recurring ETL completed successfully in %.3fs (success=%s, errors=%s)",
+            entry["duration_seconds"],
+            entry["totals"]["success"],
+            entry["totals"]["errors"],
+        )
+        logger.info("Recurring ETL completed successfully")
+        return True
+    except Exception as exc:
+        finished_at = time.time()
+        entry = _build_audit_entry(
+            started_at=started_at,
+            finished_at=finished_at,
+            status="failed",
+            error=str(exc),
+        )
+        _append_audit_entry(entry)
+        logger.error("Recurring ETL failed:\n%s", traceback.format_exc())
+        return False
+
+
+def main() -> int:
+    return 0 if run_etl() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_whoop_headless_refresh.py
+++ b/tests/test_whoop_headless_refresh.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+import json
+
+import urllib.parse
+
+from whoopdata.analysis.whoop_client import Whoop as AnalysisWhoop
+from whoopdata.clients.whoop_client import Whoop as LegacyWhoop
+from scripts import scheduled_etl
+
+
+class DummyResponse:
+    def __init__(self, payload: dict, status_code: int = 200, text: str = ""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_analysis_client_credentials_persists_refresh_metadata(monkeypatch):
+    client = AnalysisWhoop(client_id="client-id", client_secret="client-secret")
+    saved = {}
+
+    def fake_post(url, data=None, headers=None):
+        assert data["grant_type"] == "client_credentials"
+        assert "offline" in data["scope"].split()
+        return DummyResponse(
+            {
+                "access_token": "access-123",
+                "refresh_token": "refresh-456",
+                "expires_in": 3600,
+            }
+        )
+
+    def fake_save():
+        saved["access_token"] = client.access_token
+        saved["refresh_token"] = client.refresh_token
+        saved["expires_at"] = client.token_expires_at
+
+    monkeypatch.setattr("whoopdata.analysis.whoop_client.requests.post", fake_post)
+    monkeypatch.setattr(client, "_save_tokens", fake_save)
+
+    client._authenticate_client_credentials()
+
+    assert saved["access_token"] == "access-123"
+    assert saved["refresh_token"] == "refresh-456"
+    assert saved["expires_at"] is not None
+
+
+def test_legacy_client_auth_url_requests_offline_scope(monkeypatch):
+    client = LegacyWhoop(client_id="client-id", client_secret="client-secret")
+    captured = {}
+
+    class DummyServer:
+        def serve_forever(self):
+            return None
+
+        def shutdown(self):
+            return None
+
+    def fake_http_server(address, handler_cls):
+        return DummyServer()
+
+    class DummyThread:
+        daemon = False
+
+        def __init__(self, target=None):
+            self.target = target
+
+        def start(self):
+            return None
+
+    def fake_open(url):
+        captured["url"] = url
+        return True
+
+    def fake_sleep(_seconds):
+        raise RuntimeError("stop after auth url generation")
+
+    monkeypatch.setattr("http.server.HTTPServer", fake_http_server)
+    monkeypatch.setattr("threading.Thread", DummyThread)
+    monkeypatch.setattr("webbrowser.open", fake_open)
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    try:
+        client._authenticate_authorization_code()
+    except RuntimeError as exc:
+        assert str(exc) == "stop after auth url generation"
+    else:
+        raise AssertionError("expected auth flow to stop after URL capture")
+
+    parsed = urllib.parse.urlparse(captured["url"])
+    params = urllib.parse.parse_qs(parsed.query)
+    scope = params["scope"][0].split()
+    assert "offline" in scope
+    assert "read:recovery" in scope
+
+
+def test_scheduled_etl_audit_entry_summarizes_results():
+    entry = scheduled_etl._build_audit_entry(
+        started_at=100.0,
+        finished_at=104.25,
+        status="success",
+        results={
+            "whoop_sleep": {"success": 5, "errors": 0},
+            "withings_weight": {"success": 2, "errors": 1},
+        },
+    )
+
+    assert entry["job"] == "scheduled_etl"
+    assert entry["status"] == "success"
+    assert entry["duration_seconds"] == 4.25
+    assert entry["totals"] == {"success": 7, "errors": 1}
+    assert entry["sources"]["withings_weight"] == {"success": 2, "errors": 1}
+
+
+def test_scheduled_etl_appends_json_line(tmp_path, monkeypatch):
+    audit_path = tmp_path / "etl-audit.log"
+
+    monkeypatch.setattr(scheduled_etl, "LOGS_DIR", str(tmp_path))
+    monkeypatch.setattr(scheduled_etl, "AUDIT_LOG_PATH", str(audit_path))
+
+    scheduled_etl._append_audit_entry({"job": "scheduled_etl", "status": "success"})
+
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {"job": "scheduled_etl", "status": "success"}
+

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"

--- a/whoopdata/analysis/whoop_client.py
+++ b/whoopdata/analysis/whoop_client.py
@@ -172,7 +172,7 @@ class Whoop:
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "scope": "read:recovery read:cycles read:sleep read:workout read:profile read:body_measurement",
+            "scope": "offline read:recovery read:cycles read:sleep read:workout read:profile read:body_measurement",
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -187,6 +187,12 @@ class Whoop:
 
         response_data = r.json()
         self.access_token = response_data["access_token"]
+        if "refresh_token" in response_data:
+            self.refresh_token = response_data["refresh_token"]
+        if "expires_in" in response_data:
+            expires_in = int(response_data["expires_in"])
+            self.token_expires_at = datetime.now() + timedelta(seconds=expires_in)
+        self._save_tokens()
         self.logger.info("User Authenticated successfully with client credentials")
         print("User Authenticated with OAuth 2.0")
 
@@ -277,7 +283,7 @@ class Whoop:
         server_thread.start()
 
         # Create authorization URL - use the exact same callback_url format for both auth and token exchange
-        auth_url = f"https://api.prod.whoop.com/oauth/oauth2/auth?response_type=code&client_id={self.client_id}&redirect_uri={urllib.parse.quote(callback_url, safe='')}&scope=read:recovery%20read:cycles%20read:sleep%20read:workout%20read:profile%20read:body_measurement&state={state}"
+        auth_url = f"https://api.prod.whoop.com/oauth/oauth2/auth?response_type=code&client_id={self.client_id}&redirect_uri={urllib.parse.quote(callback_url, safe='')}&scope=offline%20read:recovery%20read:cycles%20read:sleep%20read:workout%20read:profile%20read:body_measurement&state={state}"
 
         print(f"\nPlease visit this URL to authorize the application: {auth_url}")
         print("Opening browser...")

--- a/whoopdata/clients/whoop_client.py
+++ b/whoopdata/clients/whoop_client.py
@@ -172,7 +172,7 @@ class Whoop:
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "scope": "read:recovery read:cycles read:sleep read:workout read:profile read:body_measurement",
+            "scope": "offline read:recovery read:cycles read:sleep read:workout read:profile read:body_measurement",
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -187,6 +187,12 @@ class Whoop:
 
         response_data = r.json()
         self.access_token = response_data["access_token"]
+        if "refresh_token" in response_data:
+            self.refresh_token = response_data["refresh_token"]
+        if "expires_in" in response_data:
+            expires_in = int(response_data["expires_in"])
+            self.token_expires_at = datetime.now() + timedelta(seconds=expires_in)
+        self._save_tokens()
         self.logger.info("User Authenticated successfully with client credentials")
         print("User Authenticated with OAuth 2.0")
 
@@ -277,7 +283,7 @@ class Whoop:
         server_thread.start()
 
         # Create authorization URL - use the exact same callback_url format for both auth and token exchange
-        auth_url = f"https://api.prod.whoop.com/oauth/oauth2/auth?response_type=code&client_id={self.client_id}&redirect_uri={urllib.parse.quote(callback_url, safe='')}&scope=read:recovery%20read:sleep%20read:workout%20read:profile%20read:body_measurement&state={state}"
+        auth_url = f"https://api.prod.whoop.com/oauth/oauth2/auth?response_type=code&client_id={self.client_id}&redirect_uri={urllib.parse.quote(callback_url, safe='')}&scope=offline%20read:recovery%20read:sleep%20read:workout%20read:profile%20read:body_measurement&state={state}"
 
         print(f"\nPlease visit this URL to authorize the application: {auth_url}")
         print("Opening browser...")


### PR DESCRIPTION
## Summary
- add recurring headless ETL scheduling for WHOOP and Withings refreshes
- request offline WHOOP scope and persist token metadata for headless refresh
- add concise audit logging, release notes, and 3.4.0 version bump

## Testing
- uv run pytest tests/test_whoop_headless_refresh.py tests/test_whoop_v2_migration.py

Co-Authored-By: Oz <oz-agent@warp.dev>