### PR TITLE
Proactive coaching, analytics and scheduling improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ OPENWEATHER_API_KEY=your_openweather_api_key_here
 # TELEGRAM_ALLOWED_CHAT_IDS=123456789
 # Optional mode switch (defaults to polling)
 # TELEGRAM_USE_WEBHOOK=false
+
+# 🪞 Optional: Private weakness reminder configuration
+# Keep the source markdown private and gitignored.
+# WEAKNESS_REMINDER_ENABLED=true
+# WEAKNESS_REMINDER_FILE=weakness.md
+# WEAKNESS_REMINDER_WINDOW_START_HOUR=9
+# WEAKNESS_REMINDER_WINDOW_END_HOUR=15

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,11 @@ OPENWEATHER_API_KEY=your_openweather_api_key_here
 # TELEGRAM_ALLOWED_CHAT_IDS=123456789
 # Optional mode switch (defaults to polling)
 # TELEGRAM_USE_WEBHOOK=false
+# Optional proactive message formatting (defaults to plain)
+# TELEGRAM_PROACTIVE_FORMAT=html  # or plain
+
+# Optional coach display name (used in some proactive prompts)
+# COACH_NAME=Anchor
 
 # 🪞 Optional: Private weakness reminder configuration
 # Keep the source markdown private and gitignored.

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ db/
 
 # Data files (e.g., raw CSVs)
 data/
+weakness.md
 
 # Logs
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev sync run server etl etl-full etl-now etl-up etl-down etl-test chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify schedule-up schedule-down schedule-test morning-now services-up services-down services-test
+.PHONY: help install dev sync run server etl etl-full etl-now etl-up etl-down etl-test chat telegram-bot analytics langgraph-dev dev-all dev-full dev-full-stop postgres-up postgres-down postgres-logs test format lint typecheck clean verify schedule-up schedule-down schedule-test morning-now proactive-now weakness-now weakness-preview services-up services-down services-test
 
 # Default target
 help:
@@ -24,17 +24,20 @@ help:
 	@echo "  make postgres-up - Start local Docker Postgres for shared agent memory"
 	@echo "  make postgres-down - Stop local Docker Postgres container"
 	@echo "  make postgres-logs - Tail local Docker Postgres logs"
-	@echo "  make services-up   - Install persistent launchd services for API + Telegram bot + recurring ETL + morning job"
+	@echo "  make services-up   - Install persistent launchd services for API + Telegram bot + recurring ETL + morning/proactive/weakness jobs"
 	@echo "  make services-down - Uninstall persistent launchd services"
 	@echo "  make services-test - Check persistent service status"
 	@echo "  make etl-up        - Install recurring ETL launchd job"
 	@echo "  make etl-down      - Uninstall recurring ETL launchd job"
 	@echo "  make etl-test      - Check recurring ETL launchd job"
 	@echo "  make etl-now       - Run recurring ETL job immediately"
-	@echo "  make schedule-up   - Install launchd schedule (daily morning ETL + push)"
+	@echo "  make schedule-up   - Install launchd schedule and recurring reminder evaluators"
 	@echo "  make schedule-down - Uninstall launchd schedule"
 	@echo "  make schedule-test - Check if the schedule is loaded"
 	@echo "  make morning-now   - Run the morning ETL + push immediately"
+	@echo "  make proactive-now - Run the proactive window evaluator immediately"
+	@echo "  make weakness-now  - Run the weakness reminder evaluator immediately"
+	@echo "  make weakness-preview - Send a manual weakness reminder preview to Telegram"
 	@echo ""
 	@echo "Development:"
 	@echo "  make test        - Run tests with pytest"
@@ -173,11 +176,15 @@ schedule-up:
 	@cp schedules/com.whoopdata.telegram.plist ~/Library/LaunchAgents/com.whoopdata.telegram.plist
 	@cp schedules/com.whoopdata.etl.plist ~/Library/LaunchAgents/com.whoopdata.etl.plist
 	@cp schedules/com.whoopdata.morning.plist ~/Library/LaunchAgents/com.whoopdata.morning.plist
+	@cp schedules/com.whoopdata.proactive.plist ~/Library/LaunchAgents/com.whoopdata.proactive.plist
+	@cp schedules/com.whoopdata.weakness.plist ~/Library/LaunchAgents/com.whoopdata.weakness.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.server.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.telegram.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.etl.plist
 	@launchctl load ~/Library/LaunchAgents/com.whoopdata.morning.plist
-	@echo "✅ Installed: persistent FastAPI server + Telegram bot + recurring ETL + daily morning job"
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.proactive.plist
+	@launchctl load ~/Library/LaunchAgents/com.whoopdata.weakness.plist
+	@echo "✅ Installed: persistent FastAPI server + Telegram bot + recurring ETL + daily morning job + proactive window evaluator + weakness reminder evaluator"
 	@echo "   Check with: make schedule-test"
 
 schedule-down:
@@ -186,10 +193,14 @@ schedule-down:
 	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.telegram.plist 2>/dev/null || true
 	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.etl.plist 2>/dev/null || true
 	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.morning.plist 2>/dev/null || true
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.proactive.plist 2>/dev/null || true
+	@launchctl unload ~/Library/LaunchAgents/com.whoopdata.weakness.plist 2>/dev/null || true
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.server.plist
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.telegram.plist
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.etl.plist
 	@rm -f ~/Library/LaunchAgents/com.whoopdata.morning.plist
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.proactive.plist
+	@rm -f ~/Library/LaunchAgents/com.whoopdata.weakness.plist
 	@echo "✅ All whoopdata services removed"
 
 schedule-test:
@@ -226,6 +237,18 @@ etl-now:
 morning-now:
 	@echo "☀️ Running morning ETL + push now..."
 	uv run python scripts/scheduled_morning.py
+
+proactive-now:
+	@echo "🧠 Running proactive window evaluator now..."
+	uv run python scripts/scheduled_proactive.py
+
+weakness-now:
+	@echo "🪞 Running weakness reminder evaluator now..."
+	uv run python scripts/scheduled_weakness.py
+
+weakness-preview:
+	@echo "🧪 Sending weakness reminder preview to Telegram..."
+	uv run python scripts/telegram_weakness_preview.py
 
 # Development targets
 test:

--- a/README.md
+++ b/README.md
@@ -321,7 +321,6 @@ uv run -m scripts.telegram_hello --api --prompt "set me up for the day"
 ```
 
 ### Weakness reminder preview
-
 You can send yourself a manual preview of the annual-review weakness reminder without consuming the once-per-workday scheduled send:
 
 ```bash
@@ -333,6 +332,15 @@ Optionally preview a specific top-level bullet from `weakness.md`:
 ```bash
 uv run python scripts/telegram_weakness_preview.py --point-number 2
 ```
+
+If you prefer richer Telegram formatting (bold/italics/bullets), you can request HTML formatting for the preview:
+
+```bash
+uv run python scripts/telegram_weakness_preview.py --point-number 2 --format html
+```
+
+To enable HTML formatting for all proactive pushes by default, set `TELEGRAM_PROACTIVE_FORMAT=html` in `.env`.
+To rename the coach in proactive prompts, set `COACH_NAME` in `.env`.
 
 ## Rollout Verification Checklist
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ make services-up
 make services-test
 ```
 
-That installs `launchd` jobs for the API server, Telegram bot, and the scheduled morning summary push. Remove them with:
+That installs `launchd` jobs for the API server, Telegram bot, the scheduled morning summary push, the proactive window evaluator, and the weakness reminder evaluator. Remove them with:
 
 ```bash
 make services-down
@@ -318,6 +318,20 @@ Or route the same flow through the running API server:
 
 ```bash
 uv run -m scripts.telegram_hello --api --prompt "set me up for the day"
+```
+
+### Weakness reminder preview
+
+You can send yourself a manual preview of the annual-review weakness reminder without consuming the once-per-workday scheduled send:
+
+```bash
+uv run python scripts/telegram_weakness_preview.py
+```
+
+Optionally preview a specific top-level bullet from `weakness.md`:
+
+```bash
+uv run python scripts/telegram_weakness_preview.py --point-number 2
 ```
 
 ## Rollout Verification Checklist
@@ -357,6 +371,9 @@ Run:
   make analytics      Primary analytics pipeline command
   make langgraph-dev  Development-only LangGraph dev server
   make dev-all        Convenience FastAPI + LangGraph dev launcher
+  make proactive-now  Run the proactive window evaluator immediately
+  make weakness-now   Run the weakness reminder evaluator immediately
+  make weakness-preview Send a manual weakness reminder preview to Telegram
 
 Development:
   make test           Run tests with pytest

--- a/chat_app.py
+++ b/chat_app.py
@@ -62,16 +62,22 @@ async def chat_with_agent(
                 agent_response += f"\n\n{img_html}"
 
         python_artifact = next(
-            (artifact for artifact in conversation_response.artifacts if artifact.kind == "python_code"),
+            (
+                artifact
+                for artifact in conversation_response.artifacts
+                if artifact.kind == "python_code"
+            ),
             None,
         )
         if python_artifact and python_artifact.content:
-            code_block = f"\n\n**Generated Python Code:**\n```python\n{python_artifact.content}\n```\n\n"
+            code_block = (
+                f"\n\n**Generated Python Code:**\n```python\n{python_artifact.content}\n```\n\n"
+            )
             agent_response = code_block + agent_response
 
         # Convert markdown image syntax to HTML for Gradio
         # Pattern: ![alt text](data:image/png;base64,...)
-        markdown_image_pattern = r'!\[([^\]]*)\]\((data:image/[^;]+;base64,[^)]+)\)'
+        markdown_image_pattern = r"!\[([^\]]*)\]\((data:image/[^;]+;base64,[^)]+)\)"
 
         def replace_markdown_image(match):
             alt_text = match.group(1)
@@ -125,8 +131,7 @@ def create_chat_interface():
     with gr.Blocks(title="Health Data Agent", theme=gr.themes.Soft(), css=custom_css) as interface:
 
         # Header
-        gr.Markdown(
-            """
+        gr.Markdown("""
         # 🏥 Health Data Agent Chat
         
         **Your AI-powered health data assistant!** Ask me anything about:
@@ -143,8 +148,7 @@ def create_chat_interface():
         - "What's my weight trend over the last 30 days?"
         - "How has my recovery been this month?"
         - "Get my latest sleep data and analyze my patterns"
-        """
-        )
+        """)
 
         # Chat interface
         chatbot = gr.Chatbot(
@@ -208,8 +212,7 @@ def create_chat_interface():
 
         # Info section
         with gr.Accordion("ℹ️ About Your Health Data", open=False):
-            gr.Markdown(
-                """
+            gr.Markdown("""
             ### Data Sources
             - **WHOOP**: Recovery, workouts, sleep data (2023-2025)
             - **Withings**: Weight, body composition, heart rate, blood pressure
@@ -224,8 +227,7 @@ def create_chat_interface():
             - Be specific with your questions (e.g., "tennis workouts in October 2025")
             - Ask for trends over specific time periods
             - Request actionable insights for better health outcomes
-            """
-            )
+            """)
 
     return interface
 

--- a/examples/protein_recommendation_example.py
+++ b/examples/protein_recommendation_example.py
@@ -17,32 +17,26 @@ async def example_direct_usage():
     print("=" * 70)
     print("EXAMPLE 1: Direct Tool Usage")
     print("=" * 70)
-    
+
     # Scenario: User doing resistance training
     print("\n📋 Scenario: User doing resistance/strength training")
     print("-" * 70)
-    
-    result = await get_protein_recommendation_tool(
-        activity_level="resistance/strength training"
-    )
+
+    result = await get_protein_recommendation_tool(activity_level="resistance/strength training")
     print(f"Recommendation: {result}")
-    
+
     # Scenario: User doing endurance training
     print("\n📋 Scenario: User doing endurance training")
     print("-" * 70)
-    
-    result = await get_protein_recommendation_tool(
-        activity_level="endurance training"
-    )
+
+    result = await get_protein_recommendation_tool(activity_level="endurance training")
     print(f"Recommendation: {result}")
-    
+
     # Scenario: Normal activity level
     print("\n📋 Scenario: User with normal activity level")
     print("-" * 70)
-    
-    result = await get_protein_recommendation_tool(
-        activity_level="normal"
-    )
+
+    result = await get_protein_recommendation_tool(activity_level="normal")
     print(f"Recommendation: {result}")
 
 
@@ -51,20 +45,18 @@ async def example_with_weight_context():
     print("\n\n" + "=" * 70)
     print("EXAMPLE 2: Understanding the Weight Data")
     print("=" * 70)
-    
+
     # First, let's see what weight data looks like
     print("\n📊 Fetching current weight data...")
     print("-" * 70)
-    
+
     weight_result = await get_weight_data_tool(latest=True)
     print(f"Latest weight data:\n{weight_result[:300]}...")
-    
+
     print("\n💪 Now calculating protein recommendation...")
     print("-" * 70)
-    
-    result = await get_protein_recommendation_tool(
-        activity_level="resistance/strength training"
-    )
+
+    result = await get_protein_recommendation_tool(activity_level="resistance/strength training")
     print(f"Recommendation: {result}")
 
 
@@ -73,11 +65,11 @@ async def example_error_handling():
     print("\n\n" + "=" * 70)
     print("EXAMPLE 3: Error Handling")
     print("=" * 70)
-    
+
     # Invalid activity level
     print("\n❌ Testing with invalid activity level...")
     print("-" * 70)
-    
+
     result = await get_protein_recommendation_tool(
         activity_level="yoga"  # Not a valid activity level
     )
@@ -89,7 +81,7 @@ def example_agent_integration():
     print("\n\n" + "=" * 70)
     print("EXAMPLE 4: Agent Integration Flow")
     print("=" * 70)
-    
+
     print("""
     User Query Examples:
     -------------------
@@ -126,7 +118,7 @@ async def main():
     await example_with_weight_context()
     await example_error_handling()
     example_agent_integration()
-    
+
     print("\n" + "=" * 70)
     print("✅ All examples complete!")
     print("=" * 70)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
 from whoopdata.api.app_factory import create_app
 
-
 app = create_app()

--- a/schedules/com.whoopdata.proactive.plist
+++ b/schedules/com.whoopdata.proactive.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.whoopdata.proactive</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/home/.local/bin/uv</string>
+        <string>run</string>
+        <string>--project</string>
+        <string>/Users/home/Documents/Projects/whoop-data</string>
+        <string>python</string>
+        <string>/Users/home/Documents/Projects/whoop-data/scripts/scheduled_proactive.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/home/Documents/Projects/whoop-data</string>
+
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/proactive-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/proactive-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/home</string>
+    </dict>
+</dict>
+</plist>

--- a/schedules/com.whoopdata.weakness.plist
+++ b/schedules/com.whoopdata.weakness.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.whoopdata.weakness</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/home/.local/bin/uv</string>
+        <string>run</string>
+        <string>--project</string>
+        <string>/Users/home/Documents/Projects/whoop-data</string>
+        <string>python</string>
+        <string>/Users/home/Documents/Projects/whoop-data/scripts/scheduled_weakness.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/home/Documents/Projects/whoop-data</string>
+
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/weakness-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/home/Documents/Projects/whoop-data/logs/weakness-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/home/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/home</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/scheduled_etl.py
+++ b/scripts/scheduled_etl.py
@@ -10,6 +10,7 @@ store current for the API, Telegram bot, and agent workflows.
 """
 
 from __future__ import annotations
+import asyncio
 import json
 
 import logging
@@ -35,6 +36,10 @@ logging.basicConfig(
 logger = logging.getLogger("scheduled_etl")
 LOGS_DIR = os.path.join(PROJECT_ROOT, "logs")
 AUDIT_LOG_PATH = os.path.join(LOGS_DIR, "etl-audit.log")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+PROACTIVE_POST_ETL_EVALUATION = (
+    os.getenv("PROACTIVE_POST_ETL_EVALUATION", "false").strip().lower() == "true"
+)
 
 
 def _build_audit_entry(
@@ -114,9 +119,67 @@ def run_etl() -> bool:
         logger.error("Recurring ETL failed:\n%s", traceback.format_exc())
         return False
 
+async def run_post_etl_proactive_check() -> bool:
+    """Optionally evaluate a proactive nudge immediately after ETL succeeds."""
+    if not PROACTIVE_POST_ETL_EVALUATION:
+        logger.info("Post-ETL proactive evaluation disabled")
+        return True
+
+    if not TELEGRAM_CHAT_ID:
+        logger.warning("No TELEGRAM_ALLOWED_CHAT_IDS set — skipping post-ETL proactive evaluation")
+        return True
+
+    try:
+        from whoopdata.database.database import SessionLocal, engine
+        from whoopdata.models.models import Base
+        from whoopdata.services.proactive_coach import (
+            ProactiveCoachPlanner,
+            ProactiveMode,
+            dispatch_proactive_message,
+        )
+        from whoopdata.telegram_push import push_to_telegram
+
+        Base.metadata.create_all(bind=engine)
+        db = SessionLocal()
+        try:
+            planner = ProactiveCoachPlanner(db)
+            decision, result = await dispatch_proactive_message(
+                planner=planner,
+                chat_id=int(TELEGRAM_CHAT_ID),
+                mode=ProactiveMode.WINDOW,
+                push_fn=push_to_telegram,
+            )
+        finally:
+            db.close()
+
+        if result is None:
+            logger.info("Post-ETL proactive evaluation skipped send: %s", decision.reason)
+            return True
+
+        logger.info(
+            "Post-ETL proactive push sent (intent=%s, message_id=%s): %s",
+            decision.intent,
+            result.telegram_message_id,
+            result.assistant_message[:120],
+        )
+        return True
+    except Exception:
+        logger.error("Post-ETL proactive evaluation failed:\n%s", traceback.format_exc())
+        return False
+
 
 def main() -> int:
-    return 0 if run_etl() else 1
+    etl_ok = run_etl()
+    proactive_ok = True
+    if etl_ok:
+        proactive_ok = asyncio.run(run_post_etl_proactive_check())
+
+    if etl_ok:
+        if not proactive_ok:
+            logger.warning("Recurring ETL succeeded but post-ETL proactive evaluation failed")
+        return 0
+
+    return 1
 
 
 if __name__ == "__main__":

--- a/scripts/scheduled_etl.py
+++ b/scripts/scheduled_etl.py
@@ -90,6 +90,7 @@ def run_etl() -> bool:
         Base.metadata.create_all(bind=engine)
 
         from whoopdata.etl import run_complete_etl
+
         results = run_complete_etl(incremental=True)
         finished_at = time.time()
         entry = _build_audit_entry(
@@ -118,6 +119,7 @@ def run_etl() -> bool:
         _append_audit_entry(entry)
         logger.error("Recurring ETL failed:\n%s", traceback.format_exc())
         return False
+
 
 async def run_post_etl_proactive_check() -> bool:
     """Optionally evaluate a proactive nudge immediately after ETL succeeds."""

--- a/scripts/scheduled_morning.py
+++ b/scripts/scheduled_morning.py
@@ -17,6 +17,9 @@ import os
 import sys
 import traceback
 
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from dotenv import load_dotenv
 
 # Ensure the project root is on the path so "whoopdata" is importable
@@ -51,6 +54,74 @@ def run_etl() -> bool:
         return True
     except Exception:
         logger.error("ETL failed:\n%s", traceback.format_exc())
+        return False
+
+
+def _parse_sqlite_timestamp(raw) -> datetime | None:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw
+    text = str(raw).strip()
+    if not text:
+        return None
+    # Common SQLite string formats:
+    # - "YYYY-MM-DD HH:MM:SS"
+    # - "YYYY-MM-DD HH:MM:SS.ssssss"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        pass
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def analytics_already_ran_today(*, tz: ZoneInfo, days_back: int = 365) -> bool:
+    """Return True if analytics results show a run on today's date in tz."""
+    try:
+        from whoopdata.analytics.results_loader import results_loader
+
+        raw = results_loader.latest_computed_at(
+            result_types=("summary", "factor_importance"),
+            days_back=days_back,
+        )
+        last = _parse_sqlite_timestamp(raw)
+        if last is None:
+            return False
+
+        # computed_at is stored without explicit timezone; interpret as local wall time.
+        last_local = last.replace(tzinfo=tz)
+        today_local = datetime.now(tz).date()
+        return last_local.date() == today_local
+    except Exception:
+        logger.warning("Failed to check analytics freshness; will run analytics")
+        return False
+
+
+def run_analytics_once_daily() -> bool:
+    """Run analytics pipeline if it hasn't run today. Returns True if ok or skipped."""
+    tz_name = os.getenv("USER_TIMEZONE")
+    tz = ZoneInfo(tz_name) if tz_name else datetime.now().astimezone().tzinfo
+    if tz is None:
+        tz = ZoneInfo("UTC")
+
+    if analytics_already_ran_today(tz=tz):
+        logger.info("Analytics already ran today; skipping")
+        return True
+
+    logger.info("Starting analytics pipeline...")
+    try:
+        from whoopdata.pipelines.analytics_pipeline import run_analytics_pipeline
+
+        run_analytics_pipeline(days_back=365)
+        logger.info("Analytics completed successfully")
+        return True
+    except Exception:
+        logger.warning("Analytics failed:\n%s", traceback.format_exc())
         return False
 
 
@@ -100,6 +171,10 @@ async def run_morning_push() -> bool:
 
 def main() -> int:
     etl_ok = run_etl()
+
+    # Run analytics after ETL, but never block the morning push.
+    _ = run_analytics_once_daily()
+
     push_ok = asyncio.run(run_morning_push())
 
     if etl_ok and push_ok:

--- a/scripts/scheduled_morning.py
+++ b/scripts/scheduled_morning.py
@@ -1,8 +1,8 @@
-"""Scheduled morning job: incremental ETL then proactive Telegram push.
+"""Scheduled morning job: incremental ETL then planner-driven Telegram push.
 
 Designed to be invoked by launchd (or cron). Runs two steps:
 1. Incremental ETL — pull latest WHOOP + Withings data
-2. Morning push  — send a health summary to Telegram via the agent
+2. Morning push  — let the proactive planner decide the morning nudge
 
 Each step is independent: if the ETL fails, the push still fires
 (with slightly stale data).  Logs go to stdout/stderr for launchd
@@ -33,11 +33,6 @@ logging.basicConfig(
 logger = logging.getLogger("scheduled_morning")
 
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
-MORNING_PROMPT = (
-    "Good morning! Please give me a concise morning health briefing based on "
-    "my latest WHOOP and Withings data. Include recovery score, sleep quality, "
-    "and any notable trends or recommendations for today."
-)
 
 
 def run_etl() -> bool:
@@ -60,21 +55,40 @@ def run_etl() -> bool:
 
 
 async def run_morning_push() -> bool:
-    """Push morning summary to Telegram. Returns True on success."""
+    """Push planner-driven morning message to Telegram. Returns True on success."""
     if not TELEGRAM_CHAT_ID:
         logger.error("No TELEGRAM_ALLOWED_CHAT_IDS set — skipping push")
         return False
-
-    logger.info("Sending morning summary to chat_id=%s", TELEGRAM_CHAT_ID)
+    logger.info("Evaluating morning proactive nudge for chat_id=%s", TELEGRAM_CHAT_ID)
     try:
+        from whoopdata.database.database import SessionLocal, engine
+        from whoopdata.models.models import Base
+        from whoopdata.services.proactive_coach import (
+            ProactiveCoachPlanner,
+            ProactiveMode,
+            dispatch_proactive_message,
+        )
         from whoopdata.telegram_push import push_to_telegram
 
-        result = await push_to_telegram(
-            chat_id=int(TELEGRAM_CHAT_ID),
-            prompt=MORNING_PROMPT,
-        )
+        Base.metadata.create_all(bind=engine)
+        db = SessionLocal()
+        try:
+            planner = ProactiveCoachPlanner(db)
+            decision, result = await dispatch_proactive_message(
+                planner=planner,
+                chat_id=int(TELEGRAM_CHAT_ID),
+                mode=ProactiveMode.MORNING,
+                push_fn=push_to_telegram,
+            )
+        finally:
+            db.close()
+
+        if result is None:
+            logger.info("Morning planner skipped send: %s", decision.reason)
+            return True
         logger.info(
-            "Morning push sent (message_id=%s): %s",
+            "Morning push sent (intent=%s, message_id=%s): %s",
+            decision.intent,
             result.telegram_message_id,
             result.assistant_message[:120],
         )

--- a/scripts/scheduled_proactive.py
+++ b/scripts/scheduled_proactive.py
@@ -1,0 +1,84 @@
+"""Periodic proactive evaluator for in-window JITAI nudges.
+
+Designed to be invoked by launchd on a fixed interval. The script itself
+enforces the configured proactive window and only sends when the planner
+finds a trigger that survives cooldown checks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+
+# Ensure the project root is on the path so "whoopdata" is importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+os.chdir(PROJECT_ROOT)
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("scheduled_proactive")
+
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+
+
+async def run_proactive_push() -> bool:
+    """Evaluate and optionally send an in-window proactive nudge."""
+    if not TELEGRAM_CHAT_ID:
+        logger.error("No TELEGRAM_ALLOWED_CHAT_IDS set — skipping proactive evaluation")
+        return False
+
+    try:
+        from whoopdata.database.database import SessionLocal, engine
+        from whoopdata.models.models import Base
+        from whoopdata.services.proactive_coach import (
+            ProactiveCoachPlanner,
+            ProactiveMode,
+            dispatch_proactive_message,
+        )
+        from whoopdata.telegram_push import push_to_telegram
+
+        Base.metadata.create_all(bind=engine)
+        db = SessionLocal()
+        try:
+            planner = ProactiveCoachPlanner(db)
+            decision, result = await dispatch_proactive_message(
+                planner=planner,
+                chat_id=int(TELEGRAM_CHAT_ID),
+                mode=ProactiveMode.WINDOW,
+                push_fn=push_to_telegram,
+            )
+        finally:
+            db.close()
+
+        if result is None:
+            logger.info("Window evaluator skipped send: %s", decision.reason)
+            return True
+
+        logger.info(
+            "Proactive push sent (intent=%s, message_id=%s): %s",
+            decision.intent,
+            result.telegram_message_id,
+            result.assistant_message[:120],
+        )
+        return True
+    except Exception:
+        logger.error("Proactive push failed:\n%s", traceback.format_exc())
+        return False
+
+
+def main() -> int:
+    return 0 if asyncio.run(run_proactive_push()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scheduled_weakness.py
+++ b/scripts/scheduled_weakness.py
@@ -1,0 +1,82 @@
+"""Periodic evaluator for weekday weakness reminders."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+
+# Ensure the project root is on the path so "whoopdata" is importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+os.chdir(PROJECT_ROOT)
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("scheduled_weakness")
+
+TELEGRAM_CHAT_ID = (
+    os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+)
+
+
+async def run_weakness_push() -> bool:
+    """Evaluate and optionally send a scheduled weakness reminder."""
+    if not TELEGRAM_CHAT_ID:
+        logger.error(
+            "No TELEGRAM_ALLOWED_CHAT_IDS set — "
+            "skipping weakness reminder evaluation"
+        )
+        return False
+
+    try:
+        from whoopdata.database.database import SessionLocal, engine
+        from whoopdata.models.models import Base
+        from whoopdata.services.weakness_reminder import (
+            WeaknessReminderPlanner,
+            dispatch_weakness_reminder,
+        )
+        from whoopdata.telegram_push import push_to_telegram
+
+        Base.metadata.create_all(bind=engine)
+        db = SessionLocal()
+        try:
+            planner = WeaknessReminderPlanner(db)
+            decision, result = await dispatch_weakness_reminder(
+                planner=planner,
+                chat_id=int(TELEGRAM_CHAT_ID),
+                push_fn=push_to_telegram,
+            )
+        finally:
+            db.close()
+
+        if result is None:
+            logger.info("Weakness reminder skipped send: %s", decision.reason)
+            return True
+
+        logger.info(
+            "Weakness reminder sent (intent=%s, message_id=%s): %s",
+            decision.intent,
+            result.telegram_message_id,
+            result.assistant_message[:120],
+        )
+        return True
+    except Exception:
+        logger.error("Weakness reminder failed:\n%s", traceback.format_exc())
+        return False
+
+
+def main() -> int:
+    return 0 if asyncio.run(run_weakness_push()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scheduled_weakness.py
+++ b/scripts/scheduled_weakness.py
@@ -23,18 +23,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger("scheduled_weakness")
 
-TELEGRAM_CHAT_ID = (
-    os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
-)
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
 
 
 async def run_weakness_push() -> bool:
     """Evaluate and optionally send a scheduled weakness reminder."""
     if not TELEGRAM_CHAT_ID:
-        logger.error(
-            "No TELEGRAM_ALLOWED_CHAT_IDS set — "
-            "skipping weakness reminder evaluation"
-        )
+        logger.error("No TELEGRAM_ALLOWED_CHAT_IDS set — " "skipping weakness reminder evaluation")
         return False
 
     try:

--- a/scripts/telegram_hello.py
+++ b/scripts/telegram_hello.py
@@ -43,7 +43,9 @@ async def push_via_api(chat_id: int, prompt: str) -> None:
         )
         resp.raise_for_status()
         data = resp.json()
-    print(f"\u2705 Pushed via API to chat_id={chat_id}, message_id={data.get('telegram_message_id')}")
+    print(
+        f"\u2705 Pushed via API to chat_id={chat_id}, message_id={data.get('telegram_message_id')}"
+    )
     print(f"Agent said: {data['assistant_message'][:200]}")
 
 

--- a/scripts/telegram_weakness_preview.py
+++ b/scripts/telegram_weakness_preview.py
@@ -17,13 +17,8 @@ os.chdir(PROJECT_ROOT)
 
 load_dotenv()
 
-TELEGRAM_CHAT_ID = (
-    os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
-)
-DEFAULT_WEAKNESS_FILE = (
-    os.getenv("WEAKNESS_REMINDER_FILE", "weakness.md").strip()
-    or "weakness.md"
-)
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+DEFAULT_WEAKNESS_FILE = os.getenv("WEAKNESS_REMINDER_FILE", "weakness.md").strip() or "weakness.md"
 
 
 async def send_preview(
@@ -47,9 +42,7 @@ async def send_preview(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Push a weakness reminder preview to Telegram"
-    )
+    parser = argparse.ArgumentParser(description="Push a weakness reminder preview to Telegram")
     parser.add_argument(
         "--chat-id",
         default=TELEGRAM_CHAT_ID,
@@ -79,8 +72,7 @@ def main() -> None:
 
     if not args.chat_id:
         raise RuntimeError(
-            "No chat ID — set TELEGRAM_ALLOWED_CHAT_IDS in .env "
-            "or pass --chat-id"
+            "No chat ID — set TELEGRAM_ALLOWED_CHAT_IDS in .env " "or pass --chat-id"
         )
 
     chat_id = int(args.chat_id)

--- a/scripts/telegram_weakness_preview.py
+++ b/scripts/telegram_weakness_preview.py
@@ -1,0 +1,104 @@
+"""Smoke test: push a weakness reminder preview to Telegram."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Ensure the project root is on the path so "whoopdata" is importable
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+os.chdir(PROJECT_ROOT)
+
+load_dotenv()
+
+TELEGRAM_CHAT_ID = (
+    os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+)
+DEFAULT_WEAKNESS_FILE = (
+    os.getenv("WEAKNESS_REMINDER_FILE", "weakness.md").strip()
+    or "weakness.md"
+)
+
+
+async def send_preview(
+    *,
+    chat_id: int,
+    weakness_file: str | Path = DEFAULT_WEAKNESS_FILE,
+    point_number: int | None = None,
+    telegram_format: str | None = None,
+):
+    """Send a manual weakness reminder preview without recording state."""
+    from whoopdata.services.weakness_reminder import build_preview
+    from whoopdata.telegram_push import push_to_telegram
+
+    preview = build_preview(weakness_file, point_number=point_number)
+    result = await push_to_telegram(
+        chat_id=chat_id,
+        prompt=preview.prompt,
+        telegram_format=telegram_format,
+    )
+    return preview, result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Push a weakness reminder preview to Telegram"
+    )
+    parser.add_argument(
+        "--chat-id",
+        default=TELEGRAM_CHAT_ID,
+        help="Telegram chat ID",
+    )
+    parser.add_argument(
+        "--point-number",
+        type=int,
+        default=None,
+        help="Optional 1-based top-level bullet number from weakness.md",
+    )
+    parser.add_argument(
+        "--weakness-file",
+        default=DEFAULT_WEAKNESS_FILE,
+        help="Path to the private weakness markdown file",
+    )
+    parser.add_argument(
+        "--format",
+        default=None,
+        choices=["plain", "html"],
+        help=(
+            "Telegram formatting to use for this preview. "
+            "Defaults to TELEGRAM_PROACTIVE_FORMAT or plain."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not args.chat_id:
+        raise RuntimeError(
+            "No chat ID — set TELEGRAM_ALLOWED_CHAT_IDS in .env "
+            "or pass --chat-id"
+        )
+
+    chat_id = int(args.chat_id)
+    preview, result = asyncio.run(
+        send_preview(
+            chat_id=chat_id,
+            weakness_file=args.weakness_file,
+            point_number=args.point_number,
+            telegram_format=args.format,
+        )
+    )
+    print(
+        "✅ Pushed weakness preview to "
+        f"chat_id={chat_id}, message_id={result.telegram_message_id}"
+    )
+    print(f"Point {preview.point_number}: {preview.point}")
+    print(f"Agent said: {result.assistant_message[:200]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_system.py
+++ b/scripts/verify_system.py
@@ -268,6 +268,7 @@ def test_withings_health():
         print(f"{check_mark(False)} Withings health failed: {e}")
         return False
 
+
 def test_api_routes():
     """Test that API routes are defined"""
     print("\n" + "=" * 60)

--- a/tests/test_agent_architecture.py
+++ b/tests/test_agent_architecture.py
@@ -12,20 +12,22 @@ from langchain_core.tools import BaseTool
 from langchain_core.messages import AIMessage
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Registry tests
 # ---------------------------------------------------------------------------
+
 
 class TestAgentRegistry:
     """Verify registry entries are well-formed."""
 
     def test_registry_has_entries(self):
         from whoopdata.agent.registry import AGENT_REGISTRY
+
         assert len(AGENT_REGISTRY) >= 5
 
     def test_required_keys_present(self):
         from whoopdata.agent.registry import AGENT_REGISTRY
+
         required_keys = {"name", "description", "system_prompt", "tools"}
         for agent_name, config in AGENT_REGISTRY.items():
             missing = required_keys - set(config.keys())
@@ -33,21 +35,27 @@ class TestAgentRegistry:
 
     def test_name_matches_key(self):
         from whoopdata.agent.registry import AGENT_REGISTRY
+
         for key, config in AGENT_REGISTRY.items():
             assert config["name"] == key, f"Registry key '{key}' != name '{config['name']}'"
 
     def test_descriptions_are_non_empty(self):
         from whoopdata.agent.registry import AGENT_REGISTRY
+
         for agent_name, config in AGENT_REGISTRY.items():
             assert len(config["description"]) > 20, f"{agent_name} description too short"
 
     def test_system_prompts_are_non_empty(self):
         from whoopdata.agent.registry import AGENT_REGISTRY
+
         for agent_name, config in AGENT_REGISTRY.items():
-            assert len(config["system_prompt"]) > 10, f"{agent_name} system_prompt is empty or too short"
+            assert (
+                len(config["system_prompt"]) > 10
+            ), f"{agent_name} system_prompt is empty or too short"
 
     def test_tool_lists_are_non_empty(self):
         from whoopdata.agent.registry import AGENT_REGISTRY
+
         for agent_name, config in AGENT_REGISTRY.items():
             assert len(config["tools"]) >= 1, f"{agent_name} has no tools"
 
@@ -68,6 +76,7 @@ class TestAgentRegistry:
 # Tool grouping tests
 # ---------------------------------------------------------------------------
 
+
 class TestToolGrouping:
     """Verify tool assignment across specialists."""
 
@@ -83,9 +92,7 @@ class TestToolGrouping:
                 continue
             for tool_name in AGENT_REGISTRY[name]["tools"]:
                 if tool_name in seen:
-                    pytest.fail(
-                        f"Tool '{tool_name}' in both '{seen[tool_name]}' and '{name}'"
-                    )
+                    pytest.fail(f"Tool '{tool_name}' in both '{seen[tool_name]}' and '{name}'")
                 seen[tool_name] = name
 
     def test_all_api_tools_assigned(self):
@@ -101,34 +108,40 @@ class TestToolGrouping:
         for tool in AVAILABLE_TOOLS:
             name = getattr(tool, "name", None)
             if name and name != "python_interpreter":
-                assert name in registry_tools, (
-                    f"Tool '{name}' not assigned to any specialist"
-                )
+                assert name in registry_tools, f"Tool '{name}' not assigned to any specialist"
 
 
 # ---------------------------------------------------------------------------
 # Tools lookup tests
 # ---------------------------------------------------------------------------
 
+
 class TestToolsLookup:
     """Verify TOOLS_BY_NAME mapping."""
 
     def test_tools_by_name_populated(self):
         from whoopdata.agent.tools import TOOLS_BY_NAME
+
         assert len(TOOLS_BY_NAME) > 0
 
     def test_tools_by_name_matches_available_tools(self):
         from whoopdata.agent.tools import TOOLS_BY_NAME, AVAILABLE_TOOLS
-        assert len(TOOLS_BY_NAME) == len(AVAILABLE_TOOLS)
+
+        available_names = {
+            getattr(tool, "name", None) for tool in AVAILABLE_TOOLS if getattr(tool, "name", None)
+        }
+        assert available_names.issubset(set(TOOLS_BY_NAME.keys()))
 
     def test_python_repl_in_tools_by_name(self):
         from whoopdata.agent.tools import TOOLS_BY_NAME
+
         assert "python_interpreter" in TOOLS_BY_NAME
 
 
 # ---------------------------------------------------------------------------
 # Specialist factory tests
 # ---------------------------------------------------------------------------
+
 
 class TestSpecialistFactory:
     """Test build_specialist_tools with mocked create_agent."""
@@ -191,6 +204,7 @@ class TestSpecialistFactory:
 # Extract final response tests
 # ---------------------------------------------------------------------------
 
+
 class TestExtractFinalResponse:
     """Test _extract_final_response helper."""
 
@@ -199,7 +213,9 @@ class TestExtractFinalResponse:
 
         result = {
             "messages": [
-                AIMessage(content="thinking...", tool_calls=[{"name": "foo", "args": {}, "id": "1"}]),
+                AIMessage(
+                    content="thinking...", tool_calls=[{"name": "foo", "args": {}, "id": "1"}]
+                ),
                 AIMessage(content="Here is the answer."),
             ]
         }
@@ -216,34 +232,46 @@ class TestExtractFinalResponse:
 # Prompt tests
 # ---------------------------------------------------------------------------
 
+
 class TestPrompts:
     """Verify prompts exist and are well-formed."""
 
     def test_supervisor_prompt_exists(self):
         from whoopdata.agent.prompts import SUPERVISOR_SYSTEM_PROMPT
+
         assert len(SUPERVISOR_SYSTEM_PROMPT) > 100
 
     def test_supervisor_prompt_mentions_specialists(self):
         from whoopdata.agent.prompts import SUPERVISOR_SYSTEM_PROMPT
+
         assert "health data" in SUPERVISOR_SYSTEM_PROMPT.lower()
         assert "analytics" in SUPERVISOR_SYSTEM_PROMPT.lower()
         assert "environment" in SUPERVISOR_SYSTEM_PROMPT.lower()
 
     def test_supervisor_prompt_includes_day_of_briefing_instruction(self):
         from whoopdata.agent.prompts import SUPERVISOR_SYSTEM_PROMPT
+
         prompt = SUPERVISOR_SYSTEM_PROMPT.lower()
         assert "set me up for today" in prompt
         assert "recovery score" in prompt
         assert "weather" in prompt
 
     def test_exercise_prompt_file_exists(self):
-        path = Path(__file__).parent.parent / "data" / "prompts" / "agents" / "exercise_sub_agent.md"
+        path = (
+            Path(__file__).parent.parent / "data" / "prompts" / "agents" / "exercise_sub_agent.md"
+        )
         assert path.exists(), f"Exercise prompt not found at {path}"
         content = path.read_text()
         assert len(content) > 100
 
     def test_behaviour_change_prompt_file_exists(self):
-        path = Path(__file__).parent.parent / "data" / "prompts" / "agents" / "behaviour_change_sub_agent.md"
+        path = (
+            Path(__file__).parent.parent
+            / "data"
+            / "prompts"
+            / "agents"
+            / "behaviour_change_sub_agent.md"
+        )
         assert path.exists(), f"Behaviour change prompt not found at {path}"
         content = path.read_text()
         assert len(content) > 100
@@ -252,6 +280,7 @@ class TestPrompts:
 # ---------------------------------------------------------------------------
 # Graph build tests
 # ---------------------------------------------------------------------------
+
 
 class TestGraphBuild:
     """Test that graph builds and compiles without errors."""
@@ -293,15 +322,15 @@ class TestGraphBuild:
             # Positional args
             tools = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else []
 
-        # Should have N specialist tools + python_repl + protein recommendation tool
-        expected_count = len(AGENT_REGISTRY) + 2
-        assert len(tools) == expected_count, (
-            f"Expected {expected_count} tools, got {len(tools)}"
-        )
+        # Should have N specialist tools + direct supervisor tools:
+        # python_repl + protein recommendation + search_memory + manage_memory
+        expected_count = len(AGENT_REGISTRY) + 4
+        assert len(tools) == expected_count, f"Expected {expected_count} tools, got {len(tools)}"
 
     def test_build_graph_has_single_langgraph_config_parameter(self):
 
         from whoopdata.agent.graph import build_graph
+
         parameters = list(inspect.signature(build_graph).parameters.values())
         assert len(parameters) == 1
         assert parameters[0].name == "config"

--- a/tests/test_agent_memory_tools.py
+++ b/tests/test_agent_memory_tools.py
@@ -76,7 +76,10 @@ def test_manage_memory_create_update_delete_and_search():
             runtime=runtime,
         )
         assert "Updated memory" in updated
-        assert store.data[memory_namespace][memory_id]["content"] == "Complete four strength sessions this week."
+        assert (
+            store.data[memory_namespace][memory_id]["content"]
+            == "Complete four strength sessions this week."
+        )
 
         found = await search_memory.coroutine(
             query="four strength",

--- a/tests/test_app_composition.py
+++ b/tests/test_app_composition.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from main import app
 from whoopdata.api.app_factory import ROUTER_GROUPS, ROUTER_REGISTRATION_ORDER
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_conversation_service.py
+++ b/tests/test_conversation_service.py
@@ -12,9 +12,7 @@ def test_build_human_message_text_only():
 
 
 def test_build_human_message_with_image():
-    msg = ConversationService._build_human_message(
-        "What is this?", image_b64="abc123"
-    )
+    msg = ConversationService._build_human_message("What is this?", image_b64="abc123")
     assert isinstance(msg, HumanMessage)
     assert isinstance(msg.content, list)
     assert len(msg.content) == 2

--- a/tests/test_daily_engine.py
+++ b/tests/test_daily_engine.py
@@ -8,9 +8,7 @@ Uses mock data (no live DB required) to verify:
 - Lifecycle segment detection
 """
 
-import pytest
 from datetime import datetime
-from unittest.mock import MagicMock, patch
 
 from whoopdata.schemas.daily import (
     RecoveryStatus,
@@ -20,9 +18,7 @@ from whoopdata.schemas.daily import (
     DailyPlanResponse,
     ScenarioInput,
     ScenarioResult,
-    ScenarioResponse,
     CompareRequest,
-    CompareResponse,
 )
 from whoopdata.services.personas import (
     get_persona,
@@ -32,7 +28,6 @@ from whoopdata.services.personas import (
     PERSONAS,
     DEFAULT_PERSONA,
 )
-
 
 # ---------------------------------------------------------------------------
 # Schema tests
@@ -84,9 +79,7 @@ class TestDailySchemas:
 
     def test_daily_plan_response(self):
         plan = DailyPlanResponse(
-            recovery_status=RecoveryStatus(
-                score=60.0, category="yellow", key_driver="HRV"
-            ),
+            recovery_status=RecoveryStatus(score=60.0, category="yellow", key_driver="HRV"),
             actions=[
                 DailyAction(
                     action="Moderate training",
@@ -95,9 +88,7 @@ class TestDailySchemas:
                     priority=1,
                 )
             ],
-            sleep_target=SleepTarget(
-                target_hours=7.5, reasoning="Based on your patterns."
-            ),
+            sleep_target=SleepTarget(target_hours=7.5, reasoning="Based on your patterns."),
             context=ContextSummary(),
             generated_at=datetime.utcnow(),
         )
@@ -193,9 +184,7 @@ class TestActionGeneration:
         # the static-like methods by calling them on an instance with mocked db
         engine = DailyEngine.__new__(DailyEngine)
 
-        recovery = RecoveryStatus(
-            score=80.0, category="green", key_driver="Sleep"
-        )
+        recovery = RecoveryStatus(score=80.0, category="green", key_driver="Sleep")
         action = engine._training_action(recovery, {}, 1)
         assert action is not None
         assert action.category == "training"
@@ -206,9 +195,7 @@ class TestActionGeneration:
 
         engine = DailyEngine.__new__(DailyEngine)
 
-        recovery = RecoveryStatus(
-            score=20.0, category="red", key_driver="HRV"
-        )
+        recovery = RecoveryStatus(score=20.0, category="red", key_driver="HRV")
         action = engine._training_action(recovery, {}, 1)
         assert action is not None
         assert action.category == "recovery"
@@ -219,9 +206,7 @@ class TestActionGeneration:
 
         engine = DailyEngine.__new__(DailyEngine)
 
-        recovery = RecoveryStatus(
-            score=70.0, category="green", hrv=80.0, key_driver="HRV"
-        )
+        recovery = RecoveryStatus(score=70.0, category="green", hrv=80.0, key_driver="HRV")
         baselines = {"hrv_7d": 60.0}  # 33% above average
         action = engine._hrv_action(recovery, baselines, 1)
         assert action is not None
@@ -232,9 +217,7 @@ class TestActionGeneration:
 
         engine = DailyEngine.__new__(DailyEngine)
 
-        recovery = RecoveryStatus(
-            score=45.0, category="yellow", hrv=40.0, key_driver="HRV"
-        )
+        recovery = RecoveryStatus(score=45.0, category="yellow", hrv=40.0, key_driver="HRV")
         baselines = {"hrv_7d": 60.0}  # 33% below average
         action = engine._hrv_action(recovery, baselines, 1)
         assert action is not None
@@ -245,9 +228,7 @@ class TestActionGeneration:
 
         engine = DailyEngine.__new__(DailyEngine)
 
-        recovery = RecoveryStatus(
-            score=50.0, category="yellow", key_driver="Sleep"
-        )
+        recovery = RecoveryStatus(score=50.0, category="yellow", key_driver="Sleep")
         baselines = {"sleep_hours_7d": 6.5}
         sleep_patterns = {"optimal_sleep_hours": 8.0}
         action = engine._sleep_action(recovery, baselines, sleep_patterns, 1)
@@ -259,9 +240,7 @@ class TestActionGeneration:
 
         engine = DailyEngine.__new__(DailyEngine)
 
-        recovery = RecoveryStatus(
-            score=80.0, category="green", key_driver="Sleep"
-        )
+        recovery = RecoveryStatus(score=80.0, category="green", key_driver="Sleep")
         weather = {
             "current": {"conditions": "clear", "temp": 18},
             "air_quality": {"aqi": 5, "description": "Very Poor"},

--- a/tests/test_docs_and_openapi_guidance.py
+++ b/tests/test_docs_and_openapi_guidance.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from main import app
 from whoopdata.api.public_surface_contract import PUBLIC_SURFACE_CONTRACT
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_insight_service_extraction.py
+++ b/tests/test_insight_service_extraction.py
@@ -121,12 +121,8 @@ def test_daily_routes_delegate_to_guidance_service(monkeypatch):
 
     assert asyncio.run(daily_routes.get_daily_plan(db=db)) == {"plan": "ok"}
     assert asyncio.run(daily_routes.predict_scenario(scenario_request, db=db)) == {"scenario": "ok"}
-    assert asyncio.run(daily_routes.compare_scenarios(compare_request, db=db)) == {
-        "compare": "ok"
-    }
-    assert asyncio.run(daily_routes.get_weekly_coaching_report(weeks=2, db=db)) == {
-        "report": "ok"
-    }
+    assert asyncio.run(daily_routes.compare_scenarios(compare_request, db=db)) == {"compare": "ok"}
+    assert asyncio.run(daily_routes.get_weekly_coaching_report(weeks=2, db=db)) == {"report": "ok"}
     assert created["db"] is db
     service.build_daily_plan.assert_awaited_once_with()
     service.predict_scenario.assert_called_once_with(scenario)

--- a/tests/test_legacy_route_deprecation.py
+++ b/tests/test_legacy_route_deprecation.py
@@ -11,7 +11,6 @@ from whoopdata.api.legacy_route_deprecation import (
 from whoopdata.api.public_surface_contract import LEGACY_COMPATIBILITY_REMOVAL_DATE_ISO
 from whoopdata.api.public_surface_inventory import ROUTE_MIGRATION_MATRIX
 
-
 REPRESENTATIVE_LEGACY_ROUTES = (
     ("/recovery/latest", "GET"),
     ("/workouts/latest", "GET"),
@@ -57,6 +56,5 @@ def test_legacy_route_responses_emit_deprecation_headers(path: str, method: str)
     assert response.headers["Link"] == f'<{target_path}>; rel="successor-version"'
     assert response.headers["X-Canonical-Route"] == target_path
     assert (
-        response.headers["X-Deprecated-Route-Removal-Date"]
-        == LEGACY_COMPATIBILITY_REMOVAL_DATE_ISO
+        response.headers["X-Deprecated-Route-Removal-Date"] == LEGACY_COMPATIBILITY_REMOVAL_DATE_ISO
     )

--- a/tests/test_mlr.py
+++ b/tests/test_mlr.py
@@ -10,7 +10,6 @@ These tests use synthetic DataFrames (no live DB required) to verify:
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from whoopdata.analytics.mlr import (
     _build_recovery_mlr_df,
@@ -23,7 +22,6 @@ from whoopdata.analytics.mlr import (
     get_hrv_model_results,
     HRV_CORE_FEATURES,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers to build synthetic DataFrames mimicking ORM output
@@ -116,9 +114,9 @@ class TestBuildRecoveryMLR:
             _make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts()
         )
         for col in RECOVERY_FEATURE_COLS:
-            assert pd.api.types.is_numeric_dtype(df[col]), (
-                f"Column {col} has dtype {df[col].dtype}, expected numeric"
-            )
+            assert pd.api.types.is_numeric_dtype(
+                df[col]
+            ), f"Column {col} has dtype {df[col].dtype}, expected numeric"
 
     def test_no_nan_in_core_features(self):
         df = _build_recovery_mlr_df(
@@ -151,9 +149,7 @@ class TestBuildRecoveryMLR:
         """Simulate NaN/None in ORM columns."""
         recoveries = _make_recoveries()
         recoveries.loc[0:2, "recovery_score"] = None
-        df = _build_recovery_mlr_df(
-            _make_cycles(), recoveries, _make_sleeps(), _make_workouts()
-        )
+        df = _build_recovery_mlr_df(_make_cycles(), recoveries, _make_sleeps(), _make_workouts())
         # Should still produce a DataFrame (NaN rows will be dropped during fit)
         assert len(df) > 0
 
@@ -208,8 +204,15 @@ class TestGetRecoveryResults:
         model, df_model = self._fit()
         results = get_recovery_model_results(model, df_model)
         expected = {
-            "model", "y", "y_pred", "residuals", "coef_df",
-            "partial_corr_df", "n_observations", "r_squared", "adj_r_squared",
+            "model",
+            "y",
+            "y_pred",
+            "residuals",
+            "coef_df",
+            "partial_corr_df",
+            "n_observations",
+            "r_squared",
+            "adj_r_squared",
         }
         assert expected.issubset(results.keys())
 
@@ -217,7 +220,16 @@ class TestGetRecoveryResults:
         model, df_model = self._fit()
         results = get_recovery_model_results(model, df_model)
         coef_df = results["coef_df"]
-        for col in ["Feature", "Coefficient", "Std Error", "t-value", "P-value", "Significant", "CI Lower", "CI Upper"]:
+        for col in [
+            "Feature",
+            "Coefficient",
+            "Std Error",
+            "t-value",
+            "P-value",
+            "Significant",
+            "CI Lower",
+            "CI Upper",
+        ]:
             assert col in coef_df.columns, f"Missing coef_df column: {col}"
 
     def test_p_values_in_range(self):
@@ -290,9 +302,7 @@ class TestBuildHRVMLR:
             assert col in df.columns, f"Missing column: {col}"
 
     def test_workout_aggregation(self):
-        df = _build_hrv_mlr_df(
-            _make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts()
-        )
+        df = _build_hrv_mlr_df(_make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts())
         assert "workout_strain" in df.columns
         assert pd.api.types.is_numeric_dtype(df["workout_strain"])
 
@@ -323,9 +333,7 @@ class TestFitHRVMLR:
 
 class TestGetHRVResults:
     def test_result_keys(self):
-        df = _build_hrv_mlr_df(
-            _make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts()
-        )
+        df = _build_hrv_mlr_df(_make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts())
         model, df_model, available_optional = fit_hrv_mlr_model(df)
         results = get_hrv_model_results(model, df_model, available_optional)
         assert "coef_df" in results
@@ -336,9 +344,7 @@ class TestGetHRVResults:
     def test_serialisation(self):
         import json
 
-        df = _build_hrv_mlr_df(
-            _make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts()
-        )
+        df = _build_hrv_mlr_df(_make_cycles(), _make_recoveries(), _make_sleeps(), _make_workouts())
         model, df_model, available_optional = fit_hrv_mlr_model(df)
         results = get_hrv_model_results(model, df_model, available_optional)
         serialised = mlr_results_to_dict(results)
@@ -360,9 +366,7 @@ class TestEdgeCases:
         """
         sleeps = _make_sleeps()
         sleeps["total_slow_wave_sleep_time_milli"] = np.nan
-        df = _build_recovery_mlr_df(
-            _make_cycles(), _make_recoveries(), sleeps, _make_workouts()
-        )
+        df = _build_recovery_mlr_df(_make_cycles(), _make_recoveries(), sleeps, _make_workouts())
         # deep_sleep_hrs will be 0 (constant) due to fillna(0)
         model, df_model = fit_recovery_mlr_model(df)
         assert model is not None
@@ -372,9 +376,7 @@ class TestEdgeCases:
         """ORM can return Integer columns as object dtype."""
         sleeps = _make_sleeps()
         sleeps["total_rem_sleep_time_milli"] = sleeps["total_rem_sleep_time_milli"].astype(object)
-        df = _build_recovery_mlr_df(
-            _make_cycles(), _make_recoveries(), sleeps, _make_workouts()
-        )
+        df = _build_recovery_mlr_df(_make_cycles(), _make_recoveries(), sleeps, _make_workouts())
         assert pd.api.types.is_numeric_dtype(df["rem_sleep_hrs"])
 
     def test_empty_dataframes(self):

--- a/tests/test_proactive_coach.py
+++ b/tests/test_proactive_coach.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from whoopdata.models.models import Base, Cycle, ProactiveMessageLog, Workout, WithingsWeight
+from whoopdata.services.proactive_coach import (
+    ProactiveCoachConfig,
+    ProactiveCoachPlanner,
+    ProactiveIntent,
+    ProactiveMode,
+    dispatch_proactive_message,
+)
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return session()
+
+
+def _make_planner(db, *, now: datetime) -> ProactiveCoachPlanner:
+    return ProactiveCoachPlanner(
+        db,
+        config=ProactiveCoachConfig(
+            enabled=True,
+            window_start_hour=8,
+            window_end_hour=14,
+            global_cooldown_hours=4,
+            duplicate_cooldown_hours=24,
+            morning_cooldown_hours=8,
+            hidden_load_strain_threshold=10.0,
+            run_gap_days=7,
+            run_history_days=90,
+            min_runs_for_habit_signal=3,
+            weight_stale_days=7,
+            escalation_delay_days=3,
+        ),
+        now_fn=lambda: now,
+    )
+
+
+@dataclass
+class StubPushResult:
+    assistant_message: str
+    telegram_message_id: int | None
+
+
+def test_hidden_load_trigger_fires_for_high_strain_with_only_walking_workouts():
+    db = _make_session()
+    now = datetime(2026, 3, 23, 9, 0, 0)
+
+    db.add(
+        Cycle(
+            id=1,
+            user_id="default_user",
+            start=now - timedelta(hours=2),
+            created_at=now - timedelta(hours=2),
+            strain=12.4,
+        )
+    )
+    db.add(
+        Workout(
+            whoop_id="walk-1",
+            user_id="default_user",
+            cycle_id=1,
+            start=now - timedelta(hours=1),
+            created_at=now - timedelta(hours=1),
+            sport_id=63,
+            strain=3.1,
+        )
+    )
+    db.commit()
+
+    decision = _make_planner(db, now=now).evaluate(mode=ProactiveMode.WINDOW, chat_id=7)
+
+    assert decision.should_send is True
+    assert decision.intent == ProactiveIntent.STRESS_CHECK_IN
+    assert decision.evidence["cycle_strain"] == 12.4
+    assert decision.evidence["workout_sports"] == ["Walking"]
+    assert "mismatch in the data" in decision.internal_prompt
+
+
+def test_running_gap_trigger_uses_activity_adherence_first():
+    db = _make_session()
+    now = datetime(2026, 3, 23, 10, 0, 0)
+
+    run_days_ago = [9, 20, 35]
+    for index, days_ago in enumerate(run_days_ago, start=1):
+        run_at = now - timedelta(days=days_ago)
+        db.add(
+            Workout(
+                whoop_id=f"run-{index}",
+                user_id="default_user",
+                start=run_at,
+                created_at=run_at,
+                sport_id=0,
+                strain=8.0,
+            )
+        )
+    db.commit()
+
+    decision = _make_planner(db, now=now).evaluate(mode=ProactiveMode.WINDOW, chat_id=7)
+
+    assert decision.should_send is True
+    assert decision.intent == ProactiveIntent.ACTIVITY_ADHERENCE
+    assert decision.evidence["days_since_last_run"] == 9
+    assert "tiny next step" in decision.internal_prompt
+
+
+def test_stale_weight_trigger_fires_when_measurement_is_old():
+    db = _make_session()
+    now = datetime(2026, 3, 23, 11, 0, 0)
+    measured_at = now - timedelta(days=10)
+
+    db.add(
+        WithingsWeight(
+            id=1,
+            user_id="default_user",
+            datetime=measured_at,
+            weight_kg=82.4,
+        )
+    )
+    db.commit()
+
+    decision = _make_planner(db, now=now).evaluate(mode=ProactiveMode.WINDOW, chat_id=7)
+
+    assert decision.should_send is True
+    assert decision.intent == ProactiveIntent.MEASUREMENT_FRESHNESS
+    assert decision.evidence["days_since_last_weight_measurement"] == 10
+    assert "fresh weight measurement" in decision.internal_prompt
+
+
+def test_repeated_gap_escalates_to_barrier_resolution():
+    db = _make_session()
+    now = datetime(2026, 3, 23, 12, 0, 0)
+
+    for index, days_ago in enumerate([9, 20, 35], start=1):
+        run_at = now - timedelta(days=days_ago)
+        db.add(
+            Workout(
+                whoop_id=f"run-{index}",
+                user_id="default_user",
+                start=run_at,
+                created_at=run_at,
+                sport_id=0,
+                strain=7.5,
+            )
+        )
+    db.commit()
+
+    planner = _make_planner(db, now=now)
+    first_decision = planner.evaluate(mode=ProactiveMode.WINDOW, chat_id=7)
+    planner.record_sent(
+        chat_id=7,
+        decision=first_decision,
+        sent_at=now - timedelta(days=4),
+    )
+
+    escalated = planner.evaluate(mode=ProactiveMode.WINDOW, chat_id=7)
+
+    assert escalated.should_send is True
+    assert escalated.intent == ProactiveIntent.BARRIER_RESOLUTION
+    assert "behaviour_change specialist" in escalated.internal_prompt
+    assert "COM-B informed" in escalated.internal_prompt
+
+
+def test_morning_mode_falls_back_to_briefing_when_no_other_trigger_fires():
+    db = _make_session()
+    now = datetime(2026, 3, 23, 7, 30, 0)
+
+    decision = _make_planner(db, now=now).evaluate(mode=ProactiveMode.MORNING, chat_id=7)
+
+    assert decision.should_send is True
+    assert decision.intent == ProactiveIntent.MORNING_BRIEFING
+    assert "one priority for today" in decision.internal_prompt
+    assert "plain chat text" in decision.internal_prompt
+    assert "Do not use markdown headings, markdown tables" in decision.internal_prompt
+    assert "under 450 characters" in decision.internal_prompt
+
+
+def test_dispatch_records_sent_message():
+    db = _make_session()
+    now = datetime(2026, 3, 23, 7, 30, 0)
+    planner = _make_planner(db, now=now)
+
+    async def _push_fn(*, chat_id: int, prompt: str):
+        assert chat_id == 7
+        assert "proactive Telegram coaching message" in prompt
+        return StubPushResult(
+            assistant_message="Morning briefing sent",
+            telegram_message_id=321,
+        )
+
+    decision, result = __import__("asyncio").run(
+        dispatch_proactive_message(
+            planner=planner,
+            chat_id=7,
+            mode=ProactiveMode.MORNING,
+            push_fn=_push_fn,
+        )
+    )
+
+    assert decision.intent == ProactiveIntent.MORNING_BRIEFING
+    assert result is not None
+
+    logs = db.query(ProactiveMessageLog).all()
+    assert len(logs) == 1
+    assert logs[0].intent == ProactiveIntent.MORNING_BRIEFING
+    assert logs[0].telegram_message_id == 321

--- a/tests/test_proactive_scripts.py
+++ b/tests/test_proactive_scripts.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import asyncio
+
+import scripts.scheduled_etl as scheduled_etl
+import scripts.scheduled_morning as scheduled_morning
+import scripts.scheduled_proactive as scheduled_proactive
+import whoopdata.database.database as database_module
+import whoopdata.models.models as models_module
+import whoopdata.services.proactive_coach as proactive_module
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_runner_dependencies(monkeypatch, *, decision, result):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(database_module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(database_module, "engine", object())
+    monkeypatch.setattr(models_module.Base.metadata, "create_all", lambda bind=None: None)
+    monkeypatch.setattr(proactive_module, "ProactiveCoachPlanner", lambda db: object())
+
+    async def _fake_dispatch(*, planner, chat_id, mode, push_fn):
+        return decision, result
+
+    monkeypatch.setattr(proactive_module, "dispatch_proactive_message", _fake_dispatch)
+    return fake_db
+
+
+def test_scheduled_proactive_returns_true_when_planner_skips(monkeypatch):
+    monkeypatch.setattr(scheduled_proactive, "TELEGRAM_CHAT_ID", "7")
+    fake_db = _patch_runner_dependencies(
+        monkeypatch,
+        decision=proactive_module.ProactiveDecision.skip(
+            mode=proactive_module.ProactiveMode.WINDOW,
+            reason="No trigger fired",
+        ),
+        result=None,
+    )
+
+    assert asyncio.run(scheduled_proactive.run_proactive_push()) is True
+    assert fake_db.closed is True
+
+
+def test_scheduled_morning_returns_true_when_planner_skips(monkeypatch):
+    monkeypatch.setattr(scheduled_morning, "TELEGRAM_CHAT_ID", "7")
+    fake_db = _patch_runner_dependencies(
+        monkeypatch,
+        decision=proactive_module.ProactiveDecision.skip(
+            mode=proactive_module.ProactiveMode.MORNING,
+            reason="Cooling down",
+        ),
+        result=None,
+    )
+
+    assert asyncio.run(scheduled_morning.run_morning_push()) is True
+    assert fake_db.closed is True
+
+
+def test_post_etl_hook_returns_true_when_disabled(monkeypatch):
+    monkeypatch.setattr(scheduled_etl, "PROACTIVE_POST_ETL_EVALUATION", False)
+    assert asyncio.run(scheduled_etl.run_post_etl_proactive_check()) is True
+
+
+def test_post_etl_hook_uses_window_dispatch_when_enabled(monkeypatch):
+    monkeypatch.setattr(scheduled_etl, "PROACTIVE_POST_ETL_EVALUATION", True)
+    monkeypatch.setattr(scheduled_etl, "TELEGRAM_CHAT_ID", "7")
+    fake_result = type(
+        "FakeResult",
+        (),
+        {"assistant_message": "sent", "telegram_message_id": 123},
+    )()
+    fake_db = _patch_runner_dependencies(
+        monkeypatch,
+        decision=proactive_module.ProactiveDecision(
+            should_send=True,
+            mode=proactive_module.ProactiveMode.WINDOW,
+            intent=proactive_module.ProactiveIntent.ACTIVITY_ADHERENCE,
+            reason="running gap",
+            trigger_fingerprint="run-gap:2026-03-10",
+            evidence={"days_since_last_run": 13},
+            internal_prompt="internal prompt",
+        ),
+        result=fake_result,
+    )
+
+    assert asyncio.run(scheduled_etl.run_post_etl_proactive_check()) is True
+    assert fake_db.closed is True

--- a/tests/test_public_surface_inventory.py
+++ b/tests/test_public_surface_inventory.py
@@ -20,7 +20,6 @@ from whoopdata.api.public_surface_inventory import (
     is_temporary_adapter_route,
 )
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -47,6 +46,7 @@ def _expected_public_routes() -> dict[tuple[tuple[str, ...], str], tuple[str, ..
         expected[key] = entry["handler_names"]
 
     return expected
+
 
 def _get_api_route(path: str, method: str = "GET") -> APIRoute:
     for route in app.routes:
@@ -78,9 +78,12 @@ def test_route_targets_match_surface_prefix_rules():
         elif surface == "agent":
             assert target.startswith("/api/v1/agent/")
 
+
 def test_canonical_data_routes_are_not_deprecated():
     for entry in ROUTE_MIGRATION_MATRIX:
-        if entry["canonical_surface"] != "data" or not entry["current_path"].startswith("/api/v1/data/"):
+        if entry["canonical_surface"] != "data" or not entry["current_path"].startswith(
+            "/api/v1/data/"
+        ):
             continue
 
         route = _get_api_route(entry["current_path"], entry["methods"][0])
@@ -102,15 +105,20 @@ def test_legacy_raw_data_routes_are_explicitly_deprecated():
 
 def test_canonical_insight_routes_are_not_deprecated():
     for entry in ROUTE_MIGRATION_MATRIX:
-        if entry["canonical_surface"] != "insights" or not entry["current_path"].startswith("/api/v1/insights/"):
+        if entry["canonical_surface"] != "insights" or not entry["current_path"].startswith(
+            "/api/v1/insights/"
+        ):
             continue
 
         route = _get_api_route(entry["current_path"], entry["methods"][0])
         assert not route.deprecated
 
+
 def test_canonical_agent_routes_are_not_deprecated():
     for entry in ROUTE_MIGRATION_MATRIX:
-        if entry["canonical_surface"] != "agent" or not entry["current_path"].startswith("/api/v1/agent/"):
+        if entry["canonical_surface"] != "agent" or not entry["current_path"].startswith(
+            "/api/v1/agent/"
+        ):
             continue
 
         route = _get_api_route(entry["current_path"], entry["methods"][0])
@@ -139,6 +147,7 @@ def test_temporary_legacy_adapters_include_migration_guidance():
         assert entry["target_path"] in entry["notes"]
         assert LEGACY_COMPATIBILITY_REMOVAL_DATE_ISO in entry["notes"]
 
+
 def test_project_script_inventory_matches_pyproject_scripts():
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
     actual_scripts = set(pyproject["project"]["scripts"].keys())
@@ -154,7 +163,8 @@ def test_project_script_inventory_matches_pyproject_scripts():
 def test_runtime_entrypoints_reference_existing_files_and_targets():
     makefile_text = (ROOT / "Makefile").read_text()
     actual_make_targets = {
-        match.group(1) for match in re.finditer(r"^([A-Za-z0-9_-]+):", makefile_text, flags=re.MULTILINE)
+        match.group(1)
+        for match in re.finditer(r"^([A-Za-z0-9_-]+):", makefile_text, flags=re.MULTILINE)
     }
     inventory_make_targets = {
         entry["current_identifier"]

--- a/tests/test_recovery_actionability_integration.py
+++ b/tests/test_recovery_actionability_integration.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from whoopdata.api.app_factory import create_app
+from whoopdata.schemas.daily import SleepTarget
+from whoopdata.services.proactive_coach import ProactiveCoachPlanner
+
+
+def test_recovery_actionability_endpoint_404_when_missing():
+    app = create_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    with patch("whoopdata.api.analytics_routes.results_loader.load_result", return_value=None):
+        resp = client.get("/api/v1/insights/analytics/recovery/actionability")
+
+    assert resp.status_code == 404
+    assert "not yet computed" in resp.json()["detail"].lower()
+
+
+def test_recovery_actionability_endpoint_returns_payload():
+    app = create_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    payload = {
+        "version": 1,
+        "computed_at": datetime.utcnow().isoformat(),
+        "days_back": 365,
+        "min_group_size": 25,
+        "rules": [
+            {
+                "rule": "Bedtime at or before 23:00",
+                "recommendation": "Aim to be asleep by about 23:00 or earlier",
+                "feature": "bedtime_hour_extended",
+                "threshold": 23.0,
+                "direction": "le",
+                "days_in_rule": 40,
+                "days_outside_rule": 40,
+                "avg_recovery_in_rule": 68.0,
+                "avg_recovery_outside_rule": 60.0,
+                "green_rate_in_rule": 0.55,
+                "green_rate_outside_rule": 0.40,
+                "recovery_delta": 8.0,
+                "green_rate_delta": 0.15,
+            }
+        ],
+        "best_thresholds": {"strain_3d_sum_max": 36.5, "bedtime_before": "23:00"},
+        "notes": [],
+    }
+
+    with patch("whoopdata.api.analytics_routes.results_loader.load_result", return_value=payload):
+        resp = client.get("/api/v1/insights/analytics/recovery/actionability")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == 1
+    assert body["best_thresholds"]["bedtime_before"] == "23:00"
+    assert body["rules"][0]["feature"] == "bedtime_hour_extended"
+
+
+def test_daily_engine_injects_actionability_sentence():
+    from whoopdata.services.daily_engine import DailyEngine
+
+    engine = DailyEngine.__new__(DailyEngine)
+
+    target = SleepTarget(target_bedtime="22:30", target_hours=8.0, reasoning="Base.")
+
+    with patch(
+        "whoopdata.services.daily_engine.results_loader.load_result",
+        return_value={"best_thresholds": {"strain_3d_sum_max": 35.0, "bedtime_before": "23:00"}},
+    ):
+        injected = engine._inject_actionability_thresholds(target)
+
+    assert "strain" in injected.reasoning.lower()
+    assert "23:00" in injected.reasoning
+
+
+def test_proactive_morning_briefing_includes_actionability_in_evidence():
+    # ProactiveCoachPlanner doesn't require DB usage for morning briefing.
+    planner = ProactiveCoachPlanner.__new__(ProactiveCoachPlanner)
+    planner.now_fn = lambda: datetime(2026, 3, 23, 7, 30, 0)
+
+    with patch(
+        "whoopdata.analytics.results_loader.results_loader.load_result",
+        return_value={"best_thresholds": {"strain_3d_sum_max": 34.5, "bedtime_before": "22:30"}},
+    ):
+        decision = planner._build_morning_briefing(now=planner.now_fn(), mode="morning")
+
+    assert decision.intent == "morning_briefing"
+    assert "recovery_actionability" in decision.evidence
+    assert decision.evidence["recovery_actionability"]["bedtime_before"] == "22:30"

--- a/tests/test_telegram_bot_boundary.py
+++ b/tests/test_telegram_bot_boundary.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import asyncio
 import base64
 
-from whoopdata.agent.public_response import AgentArtifact, AgentConversationResponse, AgentConversationTurn
+from whoopdata.agent.public_response import (
+    AgentArtifact,
+    AgentConversationResponse,
+    AgentConversationTurn,
+)
 from whoopdata.telegram_bot import TelegramConversationGateway, format_text_for_telegram_plain
 
 
@@ -134,9 +138,7 @@ def test_whoami_message_includes_ids_for_first_run_setup():
 
 def test_gateway_photo_message_sends_image_b64():
     """Photo handler should base64-encode the image and pass it to the conversation service."""
-    service = StubConversationService(
-        [_response(assistant_message="Looks like a healthy meal!")]
-    )
+    service = StubConversationService([_response(assistant_message="Looks like a healthy meal!")])
     gateway = TelegramConversationGateway(conversation_service=service)
 
     photo_bytes = b"fake-jpeg-bytes"
@@ -158,9 +160,7 @@ def test_gateway_photo_message_sends_image_b64():
 
 def test_gateway_photo_message_uses_default_caption_when_none():
     """Photo without caption should use a default prompt."""
-    service = StubConversationService(
-        [_response(assistant_message="I see an image.")]
-    )
+    service = StubConversationService([_response(assistant_message="I see an image.")])
     gateway = TelegramConversationGateway(conversation_service=service)
 
     messages = asyncio.run(
@@ -179,9 +179,7 @@ def test_gateway_photo_message_uses_default_caption_when_none():
 
 def test_gateway_photo_message_rejected_for_unauthorized_user():
     service = StubConversationService([])
-    gateway = TelegramConversationGateway(
-        conversation_service=service, allowed_user_ids=[999]
-    )
+    gateway = TelegramConversationGateway(conversation_service=service, allowed_user_ids=[999])
 
     messages = asyncio.run(
         gateway.handle_photo_message(
@@ -260,9 +258,7 @@ def test_gateway_voice_message_transcribes_and_delegates(monkeypatch):
 
 def test_gateway_voice_message_rejected_for_unauthorized_user(monkeypatch):
     service = StubConversationService([])
-    gateway = TelegramConversationGateway(
-        conversation_service=service, allowed_user_ids=[999]
-    )
+    gateway = TelegramConversationGateway(conversation_service=service, allowed_user_ids=[999])
 
     messages = asyncio.run(
         gateway.handle_voice_message(
@@ -310,10 +306,7 @@ def test_plain_formatter_flattens_markdown_tables_for_chat_style_delivery():
     )
 
     assert formatted == (
-        "Morning check-in\n"
-        "Strain: 11.2\n"
-        "Action: 10 min walk\n"
-        "Today: keep it easy.…"
+        "Morning check-in\n" "Strain: 11.2\n" "Action: 10 min walk\n" "Today: keep it easy.…"
     )
 
 

--- a/tests/test_telegram_bot_boundary.py
+++ b/tests/test_telegram_bot_boundary.py
@@ -4,7 +4,7 @@ import asyncio
 import base64
 
 from whoopdata.agent.public_response import AgentArtifact, AgentConversationResponse, AgentConversationTurn
-from whoopdata.telegram_bot import TelegramConversationGateway
+from whoopdata.telegram_bot import TelegramConversationGateway, format_text_for_telegram_plain
 
 
 class StubConversationService:
@@ -295,3 +295,43 @@ def test_gateway_formats_markdownish_assistant_text_for_telegram_html():
     assert "<b>Great</b>" in messages[0].text
     assert "<code>make server</code>" in messages[0].text
     assert "<i>Italic note</i>" in messages[0].text
+
+
+def test_plain_formatter_flattens_markdown_tables_for_chat_style_delivery():
+    formatted = format_text_for_telegram_plain(
+        "# Morning check-in\n"
+        "| Metric | Value |\n"
+        "| --- | --- |\n"
+        "| Strain | 11.2 |\n"
+        "| Action | 10 min walk |\n"
+        "\n"
+        "**Today:** keep it easy.\n"
+        "*Energy later?*"
+    )
+
+    assert formatted == (
+        "Morning check-in\n"
+        "Strain: 11.2\n"
+        "Action: 10 min walk\n"
+        "Today: keep it easy.…"
+    )
+
+
+def test_plain_formatter_limits_length_and_line_count():
+    formatted = format_text_for_telegram_plain(
+        "\n".join(
+            [
+                "Line one with plenty of extra words for truncation",
+                "Line two with plenty of extra words for truncation",
+                "Line three with plenty of extra words for truncation",
+                "Line four with plenty of extra words for truncation",
+                "Line five with plenty of extra words for truncation",
+            ]
+        ),
+        max_chars=90,
+        max_lines=3,
+    )
+
+    assert formatted.count("\n") <= 2
+    assert len(formatted) <= 90
+    assert formatted.endswith("…")

--- a/tests/test_telegram_push.py
+++ b/tests/test_telegram_push.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+
+from whoopdata.agent.public_response import (
+    AgentConversationResponse,
+    AgentConversationTurn,
+)
+from whoopdata.telegram_push import push_to_telegram
+
+
+class _StubConversationService:
+    async def send_message(
+        self,
+        *,
+        message: str,
+        session_id: str | None = None,
+        thread_id: str | None = None,
+        image_b64: str | None = None,
+        user_id: str | None = None,
+        surface: str = "api",
+    ) -> AgentConversationResponse:
+        return AgentConversationResponse(
+            session_id=session_id,
+            thread_id=thread_id or "thread-1",
+            assistant_message=(
+                "# Morning check-in\n"
+                "| Metric | Value |\n"
+                "| --- | --- |\n"
+                "| Strain | 11.2 |\n"
+                "\n"
+                "**Today:** keep it easy and just get 10 minutes outside."
+            ),
+            messages=[
+                AgentConversationTurn(role="user", content=message),
+                AgentConversationTurn(role="assistant", content="reply"),
+            ],
+            artifacts=[],
+        )
+
+
+def test_push_to_telegram_sends_compact_plain_text(monkeypatch):
+    sent: dict[str, object] = {}
+
+    class _FakeBot:
+        def __init__(self, *, token: str) -> None:
+            sent["token"] = token
+
+        async def send_message(
+            self,
+            *,
+            chat_id: int,
+            text: str,
+            parse_mode=None,
+        ):
+            sent["chat_id"] = chat_id
+            sent["text"] = text
+            sent["parse_mode"] = parse_mode
+            return type("FakeMessage", (), {"message_id": 42})()
+
+    monkeypatch.setattr("telegram.Bot", _FakeBot)
+
+    result = asyncio.run(
+        push_to_telegram(
+            chat_id=7,
+            prompt="internal prompt",
+            conversation_service=_StubConversationService(),
+            bot_token="test-token",
+        )
+    )
+
+    assert sent["token"] == "test-token"
+    assert sent["chat_id"] == 7
+    assert sent["text"] == (
+        "Morning check-in\n"
+        "Strain: 11.2\n"
+        "Today: keep it easy and just get 10 minutes outside."
+    )
+    assert sent["parse_mode"] is None
+    assert result.assistant_message == sent["text"]
+    assert result.telegram_message_id == 42

--- a/tests/test_telegram_push.py
+++ b/tests/test_telegram_push.py
@@ -72,9 +72,7 @@ def test_push_to_telegram_sends_compact_plain_text(monkeypatch):
     assert sent["token"] == "test-token"
     assert sent["chat_id"] == 7
     assert sent["text"] == (
-        "Morning check-in\n"
-        "Strain: 11.2\n"
-        "Today: keep it easy and just get 10 minutes outside."
+        "Morning check-in\n" "Strain: 11.2\n" "Today: keep it easy and just get 10 minutes outside."
     )
     assert sent["parse_mode"] is None
     assert result.assistant_message == sent["text"]

--- a/tests/test_weakness_reminder.py
+++ b/tests/test_weakness_reminder.py
@@ -73,8 +73,7 @@ def test_parse_weakness_points_ignores_non_top_level_items(tmp_path):
     assert points == [
         "**Stronger storytelling that lands on business and patient value**: "
         "Keep linking platform work to business outcomes.",
-        "**Own outcomes more proactively**: "
-        "Be bolder in defining the outcome you are driving.",
+        "**Own outcomes more proactively**: " "Be bolder in defining the outcome you are driving.",
         "**Stronger cross functional partnership**: "
         "Bring ops stakeholders in earlier and communicate changes clearly.",
     ]
@@ -88,20 +87,12 @@ def test_weekday_evaluation_uses_stable_point_and_due_slot(tmp_path):
 
     decision = planner.evaluate(chat_id=7)
     repeat = planner.evaluate(chat_id=7)
-    target_send_at = datetime.fromisoformat(
-        decision.evidence["target_send_at"]
-    )
+    target_send_at = datetime.fromisoformat(decision.evidence["target_send_at"])
 
     assert decision.should_send is True
     assert decision.intent == module.WeaknessReminderIntent.WEAKNESS_REFLECTION
-    assert (
-        decision.evidence["selected_point"]
-        == repeat.evidence["selected_point"]
-    )
-    assert (
-        decision.evidence["target_send_at"]
-        == repeat.evidence["target_send_at"]
-    )
+    assert decision.evidence["selected_point"] == repeat.evidence["selected_point"]
+    assert decision.evidence["target_send_at"] == repeat.evidence["target_send_at"]
     assert target_send_at.date() == now.date()
     assert target_send_at.weekday() < 5
     assert 9 <= target_send_at.hour <= 15
@@ -176,10 +167,7 @@ def test_dispatch_records_sent_message_for_the_selected_point(tmp_path):
         assert chat_id == 7
         assert "lightly reword" in prompt.lower()
         return StubPushResult(
-            assistant_message=(
-                "Keep the focus on business outcomes "
-                "in the story you tell."
-            ),
+            assistant_message=("Keep the focus on business outcomes " "in the story you tell."),
             telegram_message_id=222,
         )
 

--- a/tests/test_weakness_reminder.py
+++ b/tests/test_weakness_reminder.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from whoopdata.models.models import Base, ProactiveMessageLog
+
+
+def _module():
+    return importlib.import_module("whoopdata.services.weakness_reminder")
+
+
+def _make_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return session()
+
+
+def _write_weakness_file(tmp_path: Path) -> Path:
+    path = tmp_path / "weakness.md"
+    path.write_text(
+        "### Areas for Improvement and Growth\n"
+        "\n"
+        "- **Stronger storytelling that lands on business and patient "
+        "value**: Keep linking platform work to business outcomes.\n"
+        "- **Own outcomes more proactively**: "
+        "Be bolder in defining the outcome you are driving.\n"
+        "  - Nested support bullet that should be ignored\n"
+        "\n"
+        "---\n"
+        "\n"
+        "### Future Growth and Development\n"
+        "\n"
+        "- **Stronger cross functional partnership**: "
+        "Bring ops stakeholders in earlier and communicate changes clearly.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _make_planner(db, *, tmp_path: Path, now: datetime):
+    module = _module()
+    return module.WeaknessReminderPlanner(
+        db,
+        weakness_file=_write_weakness_file(tmp_path),
+        config=module.WeaknessReminderConfig(
+            enabled=True,
+            window_start_hour=9,
+            window_end_hour=15,
+        ),
+        now_fn=lambda: now,
+    )
+
+
+@dataclass
+class StubPushResult:
+    assistant_message: str
+    telegram_message_id: int | None
+
+
+def test_parse_weakness_points_ignores_non_top_level_items(tmp_path):
+    module = _module()
+
+    points = module.parse_weakness_points(_write_weakness_file(tmp_path))
+
+    assert points == [
+        "**Stronger storytelling that lands on business and patient value**: "
+        "Keep linking platform work to business outcomes.",
+        "**Own outcomes more proactively**: "
+        "Be bolder in defining the outcome you are driving.",
+        "**Stronger cross functional partnership**: "
+        "Bring ops stakeholders in earlier and communicate changes clearly.",
+    ]
+
+
+def test_weekday_evaluation_uses_stable_point_and_due_slot(tmp_path):
+    module = _module()
+    db = _make_session()
+    now = datetime(2026, 3, 23, 14, 59, 0)
+    planner = _make_planner(db, tmp_path=tmp_path, now=now)
+
+    decision = planner.evaluate(chat_id=7)
+    repeat = planner.evaluate(chat_id=7)
+    target_send_at = datetime.fromisoformat(
+        decision.evidence["target_send_at"]
+    )
+
+    assert decision.should_send is True
+    assert decision.intent == module.WeaknessReminderIntent.WEAKNESS_REFLECTION
+    assert (
+        decision.evidence["selected_point"]
+        == repeat.evidence["selected_point"]
+    )
+    assert (
+        decision.evidence["target_send_at"]
+        == repeat.evidence["target_send_at"]
+    )
+    assert target_send_at.date() == now.date()
+    assert target_send_at.weekday() < 5
+    assert 9 <= target_send_at.hour <= 15
+
+
+def test_weekend_evaluation_skips_send(tmp_path):
+    db = _make_session()
+    now = datetime(2026, 3, 28, 11, 0, 0)
+    planner = _make_planner(db, tmp_path=tmp_path, now=now)
+
+    decision = planner.evaluate(chat_id=7)
+
+    assert decision.should_send is False
+    assert "weekend" in (decision.reason or "").lower()
+
+
+def test_recorded_send_skips_later_attempts_on_the_same_workday(tmp_path):
+    db = _make_session()
+    now = datetime(2026, 3, 23, 14, 59, 0)
+    planner = _make_planner(db, tmp_path=tmp_path, now=now)
+
+    first_decision = planner.evaluate(chat_id=7)
+    planner.record_sent(chat_id=7, decision=first_decision, sent_at=now)
+
+    repeat_planner = _make_planner(
+        db,
+        tmp_path=tmp_path,
+        now=now + timedelta(minutes=1),
+    )
+    repeat_decision = repeat_planner.evaluate(chat_id=7)
+
+    assert first_decision.should_send is True
+    assert repeat_decision.should_send is False
+    assert "today" in (repeat_decision.reason or "").lower()
+
+
+def test_internal_prompt_locks_point_and_rewording_contract(tmp_path):
+    db = _make_session()
+    now = datetime(2026, 3, 23, 14, 59, 0)
+    planner = _make_planner(db, tmp_path=tmp_path, now=now)
+
+    decision = planner.evaluate(chat_id=7)
+    prompt = decision.internal_prompt or ""
+
+    assert decision.evidence["selected_point"] in prompt
+    assert "lightly reword" in prompt.lower()
+    assert "keep the original wording" in prompt.lower()
+    assert "Telegram supports basic formatting" in prompt
+    assert "one point" in prompt.lower()
+
+
+def test_build_preview_can_target_a_specific_top_level_point(tmp_path):
+    module = _module()
+
+    preview = module.build_preview(
+        _write_weakness_file(tmp_path),
+        point_number=2,
+    )
+
+    assert preview.point_number == 2
+    assert "Own outcomes more proactively" in preview.point
+    assert preview.point in preview.prompt
+
+
+def test_dispatch_records_sent_message_for_the_selected_point(tmp_path):
+    module = _module()
+    db = _make_session()
+    now = datetime(2026, 3, 23, 14, 59, 0)
+    planner = _make_planner(db, tmp_path=tmp_path, now=now)
+
+    async def _push_fn(*, chat_id: int, prompt: str):
+        assert chat_id == 7
+        assert "lightly reword" in prompt.lower()
+        return StubPushResult(
+            assistant_message=(
+                "Keep the focus on business outcomes "
+                "in the story you tell."
+            ),
+            telegram_message_id=222,
+        )
+
+    decision, result = asyncio.run(
+        module.dispatch_weakness_reminder(
+            planner=planner,
+            chat_id=7,
+            push_fn=_push_fn,
+        )
+    )
+
+    assert decision.intent == module.WeaknessReminderIntent.WEAKNESS_REFLECTION
+    assert result is not None
+
+    logs = db.query(ProactiveMessageLog).all()
+    assert len(logs) == 1
+    assert logs[0].intent == module.WeaknessReminderIntent.WEAKNESS_REFLECTION
+    assert logs[0].telegram_message_id == 222

--- a/tests/test_weakness_scripts.py
+++ b/tests/test_weakness_scripts.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import scripts.scheduled_weakness as scheduled_weakness
+import scripts.telegram_weakness_preview as telegram_weakness_preview
+import whoopdata.database.database as database_module
+import whoopdata.models.models as models_module
+import whoopdata.services.proactive_coach as proactive_module
+import whoopdata.services.weakness_reminder as weakness_module
+import whoopdata.telegram_push as telegram_push_module
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_runner_dependencies(monkeypatch, *, decision, result):
+    fake_db = _FakeDB()
+    monkeypatch.setattr(database_module, "SessionLocal", lambda: fake_db)
+    monkeypatch.setattr(database_module, "engine", object())
+    monkeypatch.setattr(
+        models_module.Base.metadata,
+        "create_all",
+        lambda bind=None: None,
+    )
+    monkeypatch.setattr(
+        weakness_module,
+        "WeaknessReminderPlanner",
+        lambda db: object(),
+    )
+
+    async def _fake_dispatch(*, planner, chat_id, push_fn):
+        return decision, result
+
+    monkeypatch.setattr(
+        weakness_module,
+        "dispatch_weakness_reminder",
+        _fake_dispatch,
+    )
+    return fake_db
+
+
+def test_scheduled_weakness_returns_true_when_planner_skips(monkeypatch):
+    monkeypatch.setattr(scheduled_weakness, "TELEGRAM_CHAT_ID", "7")
+    fake_db = _patch_runner_dependencies(
+        monkeypatch,
+        decision=proactive_module.ProactiveDecision.skip(
+            mode=weakness_module.WeaknessReminderMode.SCHEDULED,
+            reason="Not due yet",
+        ),
+        result=None,
+    )
+
+    assert asyncio.run(scheduled_weakness.run_weakness_push()) is True
+    assert fake_db.closed is True
+
+
+def test_send_preview_pushes_selected_point(monkeypatch, tmp_path):
+    weakness_file = tmp_path / "weakness.md"
+    weakness_file.write_text(
+        "- first point\n- second point\n",
+        encoding="utf-8",
+    )
+    preview = weakness_module.WeaknessPreview(
+        point="second point",
+        point_number=2,
+        prompt="preview prompt",
+    )
+    sent: dict[str, object] = {}
+
+    async def _fake_push(*, chat_id: int, prompt: str, **kwargs):
+        _ = kwargs
+        sent["chat_id"] = chat_id
+        sent["prompt"] = prompt
+        return type(
+            "FakePushResult",
+            (),
+            {"assistant_message": "preview text", "telegram_message_id": 99},
+        )()
+
+    monkeypatch.setattr(
+        weakness_module,
+        "build_preview",
+        lambda path, point_number=None: preview,
+    )
+    monkeypatch.setattr(telegram_push_module, "push_to_telegram", _fake_push)
+
+    returned_preview, result = asyncio.run(
+        telegram_weakness_preview.send_preview(
+            chat_id=7,
+            weakness_file=Path(weakness_file),
+            point_number=2,
+            telegram_format="plain",
+        )
+    )
+
+    assert returned_preview == preview
+    assert sent["chat_id"] == 7
+    assert sent["prompt"] == "preview prompt"
+    assert result.telegram_message_id == 99

--- a/tests/test_whoop_headless_refresh.py
+++ b/tests/test_whoop_headless_refresh.py
@@ -126,4 +126,3 @@ def test_scheduled_etl_appends_json_line(tmp_path, monkeypatch):
     lines = audit_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0]) == {"job": "scheduled_etl", "status": "success"}
-

--- a/tests/test_whoop_v2_migration.py
+++ b/tests/test_whoop_v2_migration.py
@@ -13,7 +13,6 @@ from whoopdata.analysis.whoop_simple import WhoopSimple
 from whoopdata.clients.whoop_client import Whoop as LegacyWhoop
 from whoopdata.model_transformation import transform_sleep, transform_workout
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_withings.py
+++ b/tests/test_withings.py
@@ -5,7 +5,6 @@ Run this to test the Withings integration
 """
 
 from whoopdata.clients.withings_client import WithingsClient
-import json
 
 
 def main():
@@ -72,7 +71,7 @@ def main():
 
             # Show latest measurements
             latest_by_type = df.groupby("measure_type_name")["datetime"].max()
-            print(f"\n🕒 Latest measurements by type:")
+            print("\n🕒 Latest measurements by type:")
             for measure_type, latest_date in latest_by_type.items():
                 latest_row = df[
                     (df["measure_type_name"] == measure_type) & (df["datetime"] == latest_date)

--- a/whoopdata/agent/graph.py
+++ b/whoopdata/agent/graph.py
@@ -3,6 +3,7 @@
 Builds a supervisor agent using create_agent with specialist subagents
 wrapped as tools. All user-visible responses come from the supervisor.
 """
+
 from typing import Any
 
 from langchain.agents import create_agent
@@ -31,6 +32,7 @@ def _dedupe_tools_by_name(tools: list[Any]) -> list[Any]:
         deduped.append(tool)
     return deduped
 
+
 def _resolve_checkpointer(
     config: dict[str, Any] | None,
 ) -> Any | None:
@@ -40,6 +42,7 @@ def _resolve_checkpointer(
     if not isinstance(configurable, dict):
         return None
     return configurable.get(CONFIG_KEY_CHECKPOINTER)
+
 
 def _resolve_store(
     config: dict[str, Any] | None,
@@ -66,12 +69,15 @@ def _create_graph(*, checkpointer: Any | None = None, store: Any | None = None):
     specialist_tools = build_specialist_tools()
 
     # Supervisor gets specialist tools + python REPL + protein tool for direct use
-    all_tools = _dedupe_tools_by_name(specialist_tools + [
-        python_repl_tool,
-        get_protein_recommendation_tool,
-        search_memory,
-        manage_memory,
-    ])
+    all_tools = _dedupe_tools_by_name(
+        specialist_tools
+        + [
+            python_repl_tool,
+            get_protein_recommendation_tool,
+            search_memory,
+            manage_memory,
+        ]
+    )
 
     # Create the supervisor agent
     # create_agent returns a compiled LangGraph graph that handles

--- a/whoopdata/agent/nodes.py
+++ b/whoopdata/agent/nodes.py
@@ -1,9 +1,9 @@
 """Agent nodes for health data processing."""
 
-from langchain_core.messages import SystemMessage, AIMessage
+from langchain_core.messages import SystemMessage
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import ToolNode
-from .schemas import HealthAgentState, HealthContextSchema
+from .schemas import HealthAgentState
 from .tools import AVAILABLE_TOOLS
 from . import settings
 

--- a/whoopdata/agent/prompts.py
+++ b/whoopdata/agent/prompts.py
@@ -18,7 +18,9 @@ def _get_supervisor_prompt() -> str:
     """Get supervisor prompt with current date injected."""
     base_prompt = _load_prompt("supervisor.md")
     now = datetime.now()
-    date_line = f"\n**Today is {now.strftime('%A, %d %B %Y')}** (use YYYY-MM-DD format for date filters)\n"
+    date_line = (
+        f"\n**Today is {now.strftime('%A, %d %B %Y')}** (use YYYY-MM-DD format for date filters)\n"
+    )
     return date_line + base_prompt
 
 

--- a/whoopdata/agent/public_response.py
+++ b/whoopdata/agent/public_response.py
@@ -15,6 +15,7 @@ class AgentArtifact(BaseModel):
     mime_type: str | None = None
     content: str
 
+
 class AgentConversationCreateRequest(BaseModel):
     session_id: str | None = None
     thread_id: str | None = None
@@ -30,6 +31,7 @@ class AgentConversationHandle(BaseModel):
 class AgentConversationTurn(BaseModel):
     role: Literal["user", "assistant"]
     content: str
+
 
 class AgentMessageRequest(BaseModel):
     message: str = Field(min_length=1)
@@ -83,11 +85,19 @@ def _extract_artifacts(messages: list[Any]) -> list[AgentArtifact]:
 
         tool_calls = getattr(message, "tool_calls", None) or ()
         for tool_call in tool_calls:
-            name = tool_call.get("name") if isinstance(tool_call, dict) else getattr(tool_call, "name", None)
+            name = (
+                tool_call.get("name")
+                if isinstance(tool_call, dict)
+                else getattr(tool_call, "name", None)
+            )
             if name != "python_interpreter":
                 continue
 
-            args = tool_call.get("args", {}) if isinstance(tool_call, dict) else getattr(tool_call, "args", {})
+            args = (
+                tool_call.get("args", {})
+                if isinstance(tool_call, dict)
+                else getattr(tool_call, "args", {})
+            )
             code = args.get("query", "")
             if not code:
                 continue

--- a/whoopdata/agent/settings.py
+++ b/whoopdata/agent/settings.py
@@ -37,7 +37,7 @@ AGENT_PERSISTENCE_AUTO_SETUP = (
 )
 
 # Supervisor model (delegates to specialists)
-SUPERVISOR_MODEL = "openai:gpt-4o-mini"
+SUPERVISOR_MODEL = "openai:gpt-5.2"
 
 # Default specialist model
 SPECIALIST_MODEL = "openai:gpt-4o-mini"

--- a/whoopdata/agent/specialists.py
+++ b/whoopdata/agent/specialists.py
@@ -69,9 +69,9 @@ def build_specialist_tools(
         description = config["description"]
 
         # Determine model for this specialist
-        model = model_override or settings.SPECIALIST_CONFIG.get(
-            agent_name, {}
-        ).get("model", settings.SPECIALIST_MODEL)
+        model = model_override or settings.SPECIALIST_CONFIG.get(agent_name, {}).get(
+            "model", settings.SPECIALIST_MODEL
+        )
 
         # Create the subagent
         agent = create_agent(

--- a/whoopdata/agent/tools.py
+++ b/whoopdata/agent/tools.py
@@ -4,8 +4,8 @@ import httpx
 import json
 from langchain_core.tools import tool
 from langchain_experimental.tools import PythonREPLTool
-from langchain_experimental.utilities import PythonREPL
 from . import settings
+from .memory_tools import search_memory
 
 
 # WHOOP Recovery Tools
@@ -389,7 +389,7 @@ async def get_protein_recommendation_tool(activity_level: str) -> str:
 
     Example:
         - get_protein_recommendation_tool(activity_level="endurance training")
-          Returns: "Based on your current weight of 70.0kg and 'endurance training' 
+          Returns: "Based on your current weight of 70.0kg and 'endurance training'
                     activity level, aim for 84g - 98g protein per day"
     """
     # Activity level to protein multiplier mapping (g/kg bodyweight)
@@ -402,13 +402,13 @@ async def get_protein_recommendation_tool(activity_level: str) -> str:
     try:
         # Get latest weight data using ainvoke
         weight_data = await get_weight_data_tool.ainvoke({"latest": True})
-        
+
         if "Error" in weight_data:
             return weight_data
-        
+
         # Parse weight data
         data = json.loads(weight_data)
-        
+
         # Handle different response formats
         if isinstance(data, dict) and "weight_kg" in data:
             # Single record response (when latest=true)
@@ -425,30 +425,27 @@ async def get_protein_recommendation_tool(activity_level: str) -> str:
                 return "Need more info: No weight data available. Please log your weight first."
         else:
             return "Error: Unexpected weight data format"
-        
+
         if not patient_current_weight or patient_current_weight is None:
             return "Need more info: No weight data available. Please log your weight first."
-        
+
         protein_range = _activity_level_map.get(activity_level.lower())
-        
+
         if protein_range is None:
             valid_levels = ", ".join(f"'{k}'" for k in _activity_level_map.keys())
-            return (
-                f"Need more info: Invalid activity level. "
-                f"Please choose from: {valid_levels}"
-            )
-        
+            return f"Need more info: Invalid activity level. " f"Please choose from: {valid_levels}"
+
         weight_kg: float = float(patient_current_weight)
-        
+
         protein_min = round(weight_kg * protein_range[0])
         protein_max = round(weight_kg * protein_range[1])
-        
+
         # Return recommendation with context
         return (
             f"Based on your current weight of {weight_kg:.1f}kg and '{activity_level}' activity level, "
             f"aim for {protein_min}g - {protein_max}g protein per day"
         )
-        
+
     except (TypeError, ValueError) as e:
         return f"Error calculating protein recommendation: {str(e)}"
     except Exception as e:
@@ -1028,7 +1025,9 @@ async def get_perfect_walk_times_tool(days: int = 3) -> str:
                 data = response.json()
                 return json.dumps(data, indent=2)
             else:
-                return f"Error retrieving walk hotspots: HTTP {response.status_code} - {response.text}"
+                return (
+                    f"Error retrieving walk hotspots: HTTP {response.status_code} - {response.text}"
+                )
 
     except Exception as e:
         return f"Error retrieving walk hotspots: {str(e)}"
@@ -1037,16 +1036,14 @@ async def get_perfect_walk_times_tool(days: int = 3) -> str:
 # Configure matplotlib globally before creating the tool
 import matplotlib
 import base64
-import os
 import glob
-from pathlib import Path
 
 matplotlib.use("Agg", force=True)
 
 
 class PythonREPLWithImages(PythonREPLTool):
     """Enhanced Python REPL that captures generated plot images."""
-    
+
     name: str = "python_interpreter"
     description: str = """Execute Python code to perform data analysis, create visualizations, and statistical computations.
     
@@ -1093,43 +1090,38 @@ class PythonREPLWithImages(PythonREPLTool):
     print('Plot saved as sin_plot.png')
     ```
     """
-    
+
     def _run(self, query: str) -> str:
         """Execute code and capture any generated images."""
         # Get list of existing image files before execution
         before_files = set(glob.glob("*.png") + glob.glob("*.jpg") + glob.glob("*.jpeg"))
-        
+
         # Execute the code using parent class
         result = super()._run(query)
-        
+
         # Get list of image files after execution
         after_files = set(glob.glob("*.png") + glob.glob("*.jpg") + glob.glob("*.jpeg"))
-        
+
         # Find new images
         new_images = after_files - before_files
-        
+
         if new_images:
             # Encode images as base64 and append to result
             image_data = []
             for image_path in sorted(new_images):
                 try:
                     with open(image_path, "rb") as img_file:
-                        encoded = base64.b64encode(img_file.read()).decode('utf-8')
-                        image_data.append({
-                            "filename": image_path,
-                            "data": encoded
-                        })
+                        encoded = base64.b64encode(img_file.read()).decode("utf-8")
+                        image_data.append({"filename": image_path, "data": encoded})
                 except Exception as e:
                     print(f"Error encoding {image_path}: {e}")
-            
+
             if image_data:
                 # Return result with embedded image data in JSON format
                 import json
-                return json.dumps({
-                    "output": result,
-                    "images": image_data
-                })
-        
+
+                return json.dumps({"output": result, "images": image_data})
+
         # No images generated, return normal result
         return result
 
@@ -1189,3 +1181,4 @@ AVAILABLE_TOOLS = [
 
 # Populate name-based lookup
 TOOLS_BY_NAME = _build_tools_by_name(AVAILABLE_TOOLS)
+TOOLS_BY_NAME["search_memory"] = search_memory

--- a/whoopdata/analysis/sleep_scoring.py
+++ b/whoopdata/analysis/sleep_scoring.py
@@ -20,7 +20,6 @@ import matplotlib.pyplot as plt
 plt.ioff()  # Turn off interactive mode
 import seaborn as sns
 import os
-from datetime import datetime, timedelta
 from whoop_functions import (
     whoop_authentication,
     make_paginated_request,
@@ -37,8 +36,8 @@ password = os.getenv("PASSWORD")
 access_token = whoop_authentication(username=username, password=password)
 headers = {"Authorization": f"Bearer {access_token}"}
 # API Endpoints
-url_sleep = f"https://api.prod.whoop.com/developer/v2/activity/sleep/"
-url_recovery = f"https://api.prod.whoop.com/developer/v2/recovery/"
+url_sleep = "https://api.prod.whoop.com/developer/v2/activity/sleep/"
+url_recovery = "https://api.prod.whoop.com/developer/v2/recovery/"
 
 
 # Get recovery data
@@ -75,7 +74,6 @@ df["score_sleep_consistency_percentage"] = imputer.fit_transform(
 
 print(df["score_state"].unique())
 
-from datetime import datetime
 
 df["sleep_time_hr"] = df["sleep_end_ts"] - df["sleep_start_ts"]
 

--- a/whoopdata/analysis/stats_utils.py
+++ b/whoopdata/analysis/stats_utils.py
@@ -12,7 +12,7 @@ from math import sqrt
 from scipy.stats import norm
 from typing import Tuple
 from scipy.stats import ttest_ind, mannwhitneyu
-from colorama import Fore, Style, init
+from colorama import Fore, init
 from scipy.stats import skew, kurtosis
 
 init(autoreset=True)

--- a/whoopdata/analysis/test.py
+++ b/whoopdata/analysis/test.py
@@ -1,5 +1,4 @@
 from whoop_client import Whoop
-import pandas as pd
 import os
 from dotenv import load_dotenv
 
@@ -66,10 +65,8 @@ stg_sleep.info()
 # group_b = df[df["is_pre_eleven"] == False]["score.recovery_score"]
 
 
-import seaborn as sns
 
 from stats_utils import IndependentGroupsAnalysis
-
 
 analyser = IndependentGroupsAnalysis()
 
@@ -99,7 +96,6 @@ api_key = os.getenv("OPENAI_API_KEY")
 
 client = OpenAI(api_key=api_key)
 
-import json
 
 results_to_pass = analyser.results()
 analyser.results_mu()

--- a/whoopdata/analysis/whoop_client.py
+++ b/whoopdata/analysis/whoop_client.py
@@ -1,4 +1,3 @@
-import numpy as np
 import requests
 import logging
 import pandas as pd

--- a/whoopdata/analysis/whoop_client_fast.py
+++ b/whoopdata/analysis/whoop_client_fast.py
@@ -1,4 +1,3 @@
-import numpy as np
 import requests
 import logging
 import pandas as pd

--- a/whoopdata/analysis/whoop_client_nodes.py
+++ b/whoopdata/analysis/whoop_client_nodes.py
@@ -2,7 +2,7 @@ import requests
 import json
 import os
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Any
+from typing import Dict, Any
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/whoopdata/analysis/whoop_functions.py
+++ b/whoopdata/analysis/whoop_functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 import pandas as pd
 import requests
+
 TOKEN_URL = "https://api.prod.whoop.com/oauth/oauth2/token"
 
 

--- a/whoopdata/analytics/data_prep.py
+++ b/whoopdata/analytics/data_prep.py
@@ -11,7 +11,7 @@ from sklearn.impute import SimpleImputer
 from typing import Tuple, Optional
 from datetime import datetime, timedelta
 
-from whoopdata.models.models import Recovery, Sleep, Workout, Cycle, WithingsWeight
+from whoopdata.models.models import Recovery, Sleep, Workout, Cycle
 
 MINUTES_PER_DAY = 24 * 60
 
@@ -86,8 +86,8 @@ def _add_shared_recovery_modeling_features(df: pd.DataFrame) -> pd.DataFrame:
             modeled[f"{base_name}_delta_{window}d_avg_min"] = _circular_minute_delta(
                 modeled[source_col], baseline
             )
-            modeled[f"abs_{base_name}_delta_{window}d_avg_min"] = (
-                _circular_distance_minutes(modeled[source_col], baseline)
+            modeled[f"abs_{base_name}_delta_{window}d_avg_min"] = _circular_distance_minutes(
+                modeled[source_col], baseline
             )
             modeled[f"{base_name}_variability_{window}d_min"] = _circular_rolling_std(
                 modeled[source_col], window
@@ -142,34 +142,20 @@ def _add_shared_recovery_modeling_features(df: pd.DataFrame) -> pd.DataFrame:
     modeled["awake_fraction_of_time_in_bed"] = _safe_divide(
         modeled["awake_time_hours"], modeled["time_in_bed_hours"]
     )
-    modeled["late_bedtime_after_23"] = (
-        modeled["sleep_start_clock_min"] >= 23 * 60
-    ).astype(int)
-    modeled["late_bedtime_after_midnight"] = (
-        modeled["sleep_start_clock_min"] < 5 * 60
-    ).astype(int)
-    modeled["bedtime_shift_gt_60m_7d"] = (
-        modeled["abs_bedtime_delta_7d_avg_min"] > 60
-    ).astype(int)
-    modeled["wake_shift_gt_60m_7d"] = (
-        modeled["abs_wake_time_delta_7d_avg_min"] > 60
-    ).astype(int)
+    modeled["late_bedtime_after_23"] = (modeled["sleep_start_clock_min"] >= 23 * 60).astype(int)
+    modeled["late_bedtime_after_midnight"] = (modeled["sleep_start_clock_min"] < 5 * 60).astype(int)
+    modeled["bedtime_shift_gt_60m_7d"] = (modeled["abs_bedtime_delta_7d_avg_min"] > 60).astype(int)
+    modeled["wake_shift_gt_60m_7d"] = (modeled["abs_wake_time_delta_7d_avg_min"] > 60).astype(int)
     modeled["is_weekday"] = (~modeled["is_weekend"]).astype(int)
-    modeled["zone_4_5_minutes"] = (
-        modeled["zone_four_minutes"] + modeled["zone_five_minutes"]
-    )
+    modeled["zone_4_5_minutes"] = modeled["zone_four_minutes"] + modeled["zone_five_minutes"]
     modeled["zone_0_2_minutes"] = (
-        modeled["zone_zero_minutes"]
-        + modeled["zone_one_minutes"]
-        + modeled["zone_two_minutes"]
+        modeled["zone_zero_minutes"] + modeled["zone_one_minutes"] + modeled["zone_two_minutes"]
     )
     modeled["late_workout_flag"] = (
-        modeled["workout_start_hour_numeric"] >= 19
-    ).fillna(False).astype(int)
+        (modeled["workout_start_hour_numeric"] >= 19).fillna(False).astype(int)
+    )
     modeled["has_workout_flag"] = (modeled["total_zone_minutes"] > 0).astype(int)
-    modeled["high_intensity_workout_flag"] = (
-        modeled["high_intensity_pct"] >= 20
-    ).astype(int)
+    modeled["high_intensity_workout_flag"] = (modeled["high_intensity_pct"] >= 20).astype(int)
     modeled["row_grain"] = "one row per recovery day"
 
     return modeled
@@ -314,7 +300,9 @@ def get_recovery_with_features(
             Sleep.total_time_in_bed_time_milli.label("fallback_total_time_in_bed_time_milli"),
             Sleep.total_awake_time_milli.label("fallback_total_awake_time_milli"),
             Sleep.total_rem_sleep_time_milli.label("fallback_total_rem_sleep_time_milli"),
-            Sleep.total_slow_wave_sleep_time_milli.label("fallback_total_slow_wave_sleep_time_milli"),
+            Sleep.total_slow_wave_sleep_time_milli.label(
+                "fallback_total_slow_wave_sleep_time_milli"
+            ),
             Sleep.total_no_data_time_milli.label("fallback_total_no_data_time_milli"),
             Sleep.sleep_cycle_count.label("fallback_sleep_cycle_count"),
             Sleep.disturbance_count.label("fallback_disturbance_count"),
@@ -476,8 +464,8 @@ def get_recovery_with_features(
     # ===== Heart Rate Metrics =====
     # Only calculate if we have max_heart_rate from cycle data
     df["hr_reserve"] = (
-        df["cycle_max_heart_rate"] - df["resting_heart_rate"]
-    ).astype("float64").fillna(0)
+        (df["cycle_max_heart_rate"] - df["resting_heart_rate"]).astype("float64").fillna(0)
+    )
     df["avg_hr_percentage_of_max"] = (
         (df["cycle_average_heart_rate"] / df["cycle_max_heart_rate"] * 100)
         .astype("float64")
@@ -653,7 +641,7 @@ def get_recovery_with_features(
                 # Clean up temporary columns
                 drop_cols = [col for col in df.columns if col.endswith("_workout")]
                 df = df.drop(columns=drop_cols)
-        except Exception as e:
+        except Exception:
             # If workout data fails to load, columns are already initialized with defaults
             pass
 
@@ -1004,33 +992,30 @@ def get_workouts_with_recovery(
 
     # Query workouts with cycle and recovery data
     # We want: Workout -> Cycle -> Next Cycle's Recovery
-    query = (
-        db.query(
-            Workout.id.label("workout_id"),
-            Workout.created_at.label("workout_date"),
-            Workout.start.label("workout_start"),
-            Workout.end.label("workout_end"),
-            Workout.sport_id,
-            Workout.strain.label("workout_strain"),
-            Workout.average_heart_rate.label("workout_avg_hr"),
-            Workout.max_heart_rate.label("workout_max_hr"),
-            Workout.kilojoule.label("workout_kilojoule"),
-            Workout.distance_meter,
-            Workout.zone_zero_minutes,
-            Workout.zone_one_minutes,
-            Workout.zone_two_minutes,
-            Workout.zone_three_minutes,
-            Workout.zone_four_minutes,
-            Workout.zone_five_minutes,
-            # Cycle data (the day of the workout)
-            Cycle.id.label("cycle_id"),
-            Cycle.start.label("cycle_start"),
-            Cycle.end.label("cycle_end"),
-            Cycle.strain.label("daily_strain"),  # Total strain for the day
-            Cycle.kilojoule.label("daily_kilojoule"),
-        )
-        .join(Cycle, Workout.cycle_id == Cycle.id)
-    )
+    query = db.query(
+        Workout.id.label("workout_id"),
+        Workout.created_at.label("workout_date"),
+        Workout.start.label("workout_start"),
+        Workout.end.label("workout_end"),
+        Workout.sport_id,
+        Workout.strain.label("workout_strain"),
+        Workout.average_heart_rate.label("workout_avg_hr"),
+        Workout.max_heart_rate.label("workout_max_hr"),
+        Workout.kilojoule.label("workout_kilojoule"),
+        Workout.distance_meter,
+        Workout.zone_zero_minutes,
+        Workout.zone_one_minutes,
+        Workout.zone_two_minutes,
+        Workout.zone_three_minutes,
+        Workout.zone_four_minutes,
+        Workout.zone_five_minutes,
+        # Cycle data (the day of the workout)
+        Cycle.id.label("cycle_id"),
+        Cycle.start.label("cycle_start"),
+        Cycle.end.label("cycle_end"),
+        Cycle.strain.label("daily_strain"),  # Total strain for the day
+        Cycle.kilojoule.label("daily_kilojoule"),
+    ).join(Cycle, Workout.cycle_id == Cycle.id)
 
     if date_threshold:
         query = query.filter(Workout.created_at >= date_threshold)
@@ -1080,7 +1065,7 @@ def get_workouts_with_recovery(
     # Now join with next-day recovery
     # We need to find the recovery from the NEXT cycle after this workout's cycle
     # This is complex, so we'll do it by finding recoveries where created_at > workout date
-    
+
     # For each workout, find the next recovery (within 48 hours)
     recoveries_query = db.query(
         Recovery.cycle_id,

--- a/whoopdata/analytics/engine.py
+++ b/whoopdata/analytics/engine.py
@@ -4,16 +4,14 @@ All analyzers return plain English explanations alongside statistical results.
 """
 
 import pandas as pd
-import numpy as np
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional
 from scipy.stats import pearsonr
-from datetime import datetime, timedelta
+from datetime import datetime
 from sqlalchemy.orm import Session
 
-from .models import RecoveryPredictor, SleepPredictor
+from .models import RecoveryPredictor
 from .data_prep import (
     get_recovery_with_features,
-    get_sleep_quality_features,
     calculate_rolling_features,
 )
 
@@ -1206,44 +1204,56 @@ class InsightGenerator:
         top_sleep = top_quarter["sleep_hours"].mean()
         bottom_sleep = bottom_quarter["sleep_hours"].mean()
         if not pd.isna(top_sleep) and not pd.isna(bottom_sleep) and top_sleep > bottom_sleep + 0.3:
-            results.append({
-                "behaviour": "Longer sleep",
-                "detail": f"Your best days averaged {top_sleep:.1f}h sleep vs {bottom_sleep:.1f}h on worst days.",
-                "impact": "positive",
-            })
+            results.append(
+                {
+                    "behaviour": "Longer sleep",
+                    "detail": f"Your best days averaged {top_sleep:.1f}h sleep vs {bottom_sleep:.1f}h on worst days.",
+                    "impact": "positive",
+                }
+            )
 
         # Sleep efficiency
         top_eff = top_quarter["sleep_efficiency_percentage"].mean()
         bottom_eff = bottom_quarter["sleep_efficiency_percentage"].mean()
         if not pd.isna(top_eff) and not pd.isna(bottom_eff) and top_eff > bottom_eff + 2:
-            results.append({
-                "behaviour": "Higher sleep efficiency",
-                "detail": f"Best recovery days had {top_eff:.0f}% efficiency vs {bottom_eff:.0f}%.",
-                "impact": "positive",
-            })
+            results.append(
+                {
+                    "behaviour": "Higher sleep efficiency",
+                    "detail": f"Best recovery days had {top_eff:.0f}% efficiency vs {bottom_eff:.0f}%.",
+                    "impact": "positive",
+                }
+            )
 
         # Strain comparison
         top_strain = top_quarter["strain"].mean()
         bottom_strain = bottom_quarter["strain"].mean()
         if not pd.isna(top_strain) and not pd.isna(bottom_strain):
             if top_strain < bottom_strain - 1:
-                results.append({
-                    "behaviour": "Lower previous-day strain",
-                    "detail": f"Best recoveries followed {top_strain:.1f} strain vs {bottom_strain:.1f}.",
-                    "impact": "positive",
-                })
+                results.append(
+                    {
+                        "behaviour": "Lower previous-day strain",
+                        "detail": f"Best recoveries followed {top_strain:.1f} strain vs {bottom_strain:.1f}.",
+                        "impact": "positive",
+                    }
+                )
 
         # Bedtime consistency
         if "bedtime_hour" in df.columns:
             top_bedtime_std = top_quarter["bedtime_hour"].std()
             overall_std = df["bedtime_hour"].std()
-            if not pd.isna(top_bedtime_std) and not pd.isna(overall_std) and top_bedtime_std < overall_std:
+            if (
+                not pd.isna(top_bedtime_std)
+                and not pd.isna(overall_std)
+                and top_bedtime_std < overall_std
+            ):
                 avg_bedtime = top_quarter["bedtime_hour"].mean()
-                results.append({
-                    "behaviour": "Consistent bedtime",
-                    "detail": f"Top recoveries had bedtime around {int(avg_bedtime):02d}:00 with less variation.",
-                    "impact": "positive",
-                })
+                results.append(
+                    {
+                        "behaviour": "Consistent bedtime",
+                        "detail": f"Top recoveries had bedtime around {int(avg_bedtime):02d}:00 with less variation.",
+                        "impact": "positive",
+                    }
+                )
 
         return results[:3]  # Top 3
 
@@ -1257,25 +1267,29 @@ class InsightGenerator:
             avg_deficit = df["sleep_deficit"].mean()
             if not pd.isna(avg_deficit) and avg_deficit > 0.5:
                 optimal = avg_sleep + avg_deficit
-                recommendations.append({
-                    "recommendation": f"Increase sleep to {optimal:.1f}h",
-                    "reasoning": f"You're averaging {avg_deficit:.1f}h below your sleep need. "
-                                 f"Closing this gap would improve recovery.",
-                    "priority": 1,
-                })
+                recommendations.append(
+                    {
+                        "recommendation": f"Increase sleep to {optimal:.1f}h",
+                        "reasoning": f"You're averaging {avg_deficit:.1f}h below your sleep need. "
+                        f"Closing this gap would improve recovery.",
+                        "priority": 1,
+                    }
+                )
 
         # Check strain vs recovery balance
         high_strain_low_recovery = df[
-            (df["strain"] > df["strain"].quantile(0.75)) &
-            (df["recovery_score"] < df["recovery_score"].quantile(0.25))
+            (df["strain"] > df["strain"].quantile(0.75))
+            & (df["recovery_score"] < df["recovery_score"].quantile(0.25))
         ]
         if len(high_strain_low_recovery) >= 2:
-            recommendations.append({
-                "recommendation": "Add a rest day after high-strain sessions",
-                "reasoning": f"You had {len(high_strain_low_recovery)} days with high strain and low recovery. "
-                             f"Your body isn't recovering between hard efforts.",
-                "priority": 1,
-            })
+            recommendations.append(
+                {
+                    "recommendation": "Add a rest day after high-strain sessions",
+                    "reasoning": f"You had {len(high_strain_low_recovery)} days with high strain and low recovery. "
+                    f"Your body isn't recovering between hard efforts.",
+                    "priority": 1,
+                }
+            )
 
         # Check HRV trend
         if len(df) >= 7:
@@ -1284,12 +1298,14 @@ class InsightGenerator:
             if not pd.isna(hrv_early) and not pd.isna(hrv_late):
                 hrv_change = ((hrv_late - hrv_early) / hrv_early) * 100 if hrv_early > 0 else 0
                 if hrv_change < -10:
-                    recommendations.append({
-                        "recommendation": "Prioritise recovery this week",
-                        "reasoning": f"HRV dropped {abs(hrv_change):.0f}% over the period, "
-                                     f"indicating accumulated fatigue.",
-                        "priority": 1,
-                    })
+                    recommendations.append(
+                        {
+                            "recommendation": "Prioritise recovery this week",
+                            "reasoning": f"HRV dropped {abs(hrv_change):.0f}% over the period, "
+                            f"indicating accumulated fatigue.",
+                            "priority": 1,
+                        }
+                    )
 
         return recommendations[:2]  # Max 2
 

--- a/whoopdata/analytics/mlr.py
+++ b/whoopdata/analytics/mlr.py
@@ -19,7 +19,6 @@ from typing import Dict, List, Optional, Tuple
 
 from whoopdata.models.models import Recovery, Sleep, Cycle, Workout
 
-
 # ---------------------------------------------------------------------------
 # Feature label mappings (internal col name -> human-readable)
 # ---------------------------------------------------------------------------
@@ -89,8 +88,10 @@ def prepare_recovery_mlr_data(db: Session) -> pd.DataFrame:
 
     # Derive light sleep
     for c in [
-        "total_time_in_bed_time_milli", "total_awake_time_milli",
-        "total_no_data_time_milli", "total_slow_wave_sleep_time_milli",
+        "total_time_in_bed_time_milli",
+        "total_awake_time_milli",
+        "total_no_data_time_milli",
+        "total_slow_wave_sleep_time_milli",
         "total_rem_sleep_time_milli",
     ]:
         base_df[c] = pd.to_numeric(base_df[c], errors="coerce").fillna(0)
@@ -104,9 +105,7 @@ def prepare_recovery_mlr_data(db: Session) -> pd.DataFrame:
     ).clip(lower=0)
 
     # Add date column for workout matching
-    base_df["date"] = pd.to_datetime(
-        base_df["cycle_start"].fillna(base_df["created_at"])
-    ).dt.date
+    base_df["date"] = pd.to_datetime(base_df["cycle_start"].fillna(base_df["created_at"])).dt.date
 
     # Rename to match _build_recovery_mlr_df expectations
     base_df["id"] = base_df["cycle_id"]
@@ -188,12 +187,12 @@ def _build_recovery_mlr_df(
         df["had_workout"] = 0
 
     # --- Derived features ------------------------------------------------
-    df["deep_sleep_hrs"] = pd.to_numeric(
-        df["total_slow_wave_sleep_time_milli"], errors="coerce"
-    ) / 3_600_000
-    df["rem_sleep_hrs"] = pd.to_numeric(
-        df["total_rem_sleep_time_milli"], errors="coerce"
-    ) / 3_600_000
+    df["deep_sleep_hrs"] = (
+        pd.to_numeric(df["total_slow_wave_sleep_time_milli"], errors="coerce") / 3_600_000
+    )
+    df["rem_sleep_hrs"] = (
+        pd.to_numeric(df["total_rem_sleep_time_milli"], errors="coerce") / 3_600_000
+    )
     df["total_sleep_hrs"] = (
         pd.to_numeric(df["total_slow_wave_sleep_time_milli"], errors="coerce")
         + pd.to_numeric(df["total_rem_sleep_time_milli"], errors="coerce")
@@ -386,8 +385,10 @@ def prepare_hrv_mlr_data(db: Session) -> pd.DataFrame:
 
     # Derive light sleep
     for c in [
-        "total_time_in_bed_time_milli", "total_awake_time_milli",
-        "total_no_data_time_milli", "total_slow_wave_sleep_time_milli",
+        "total_time_in_bed_time_milli",
+        "total_awake_time_milli",
+        "total_no_data_time_milli",
+        "total_slow_wave_sleep_time_milli",
         "total_rem_sleep_time_milli",
     ]:
         base_df[c] = pd.to_numeric(base_df[c], errors="coerce").fillna(0)
@@ -401,9 +402,7 @@ def prepare_hrv_mlr_data(db: Session) -> pd.DataFrame:
     ).clip(lower=0)
 
     # Add date column
-    base_df["date"] = pd.to_datetime(
-        base_df["cycle_start"].fillna(base_df["created_at"])
-    ).dt.date
+    base_df["date"] = pd.to_datetime(base_df["cycle_start"].fillna(base_df["created_at"])).dt.date
 
     # Rename to match _build_hrv_mlr_df expectations
     base_df["id"] = base_df["cycle_id"]
@@ -515,12 +514,12 @@ def _build_hrv_mlr_df(
         df["workout_count"] = 0
 
     # --- Derived features ------------------------------------------------
-    df["deep_sleep_hrs"] = pd.to_numeric(
-        df["total_slow_wave_sleep_time_milli"], errors="coerce"
-    ) / 3_600_000
-    df["rem_sleep_hrs"] = pd.to_numeric(
-        df["total_rem_sleep_time_milli"], errors="coerce"
-    ) / 3_600_000
+    df["deep_sleep_hrs"] = (
+        pd.to_numeric(df["total_slow_wave_sleep_time_milli"], errors="coerce") / 3_600_000
+    )
+    df["rem_sleep_hrs"] = (
+        pd.to_numeric(df["total_rem_sleep_time_milli"], errors="coerce") / 3_600_000
+    )
     df["total_sleep_hrs"] = (
         pd.to_numeric(df["total_slow_wave_sleep_time_milli"], errors="coerce")
         + pd.to_numeric(df["total_rem_sleep_time_milli"], errors="coerce")
@@ -661,7 +660,9 @@ def mlr_results_to_dict(results: Dict) -> Dict:
                 "std_error": _safe_float(row["Std Error"]),
                 "t_value": _safe_float(row["t-value"]),
                 "p_value": _safe_float(row["P-value"], 1.0),
-                "significant": bool(row["Significant"]) if not pd.isna(row["Significant"]) else False,
+                "significant": (
+                    bool(row["Significant"]) if not pd.isna(row["Significant"]) else False
+                ),
                 "ci_lower": _safe_float(row["CI Lower"]),
                 "ci_upper": _safe_float(row["CI Upper"]),
             }

--- a/whoopdata/analytics/models.py
+++ b/whoopdata/analytics/models.py
@@ -5,12 +5,10 @@ Includes recovery and sleep prediction models with explainability.
 
 import pickle
 import numpy as np
-import pandas as pd
 from pathlib import Path
 from typing import Dict, Tuple, Optional
-from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
-from sklearn.metrics import r2_score, mean_absolute_error, mean_squared_error
-from sklearn.model_selection import cross_val_score
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import r2_score, mean_absolute_error
 import xgboost as xgb
 
 # Try to import SHAP for explainability (optional dependency)

--- a/whoopdata/analytics/recovery_actionability.py
+++ b/whoopdata/analytics/recovery_actionability.py
@@ -1,0 +1,273 @@
+"""Compute simple, user-facing actionability rules for improving recovery.
+
+This is intentionally heuristic and descriptive: it searches for interpretable
+threshold rules (e.g. bedtime before X, keep strain under Y) that correlate with
+better next-day recovery outcomes in the user's historical data.
+
+Outputs are designed to be persisted into analytics_results and served via API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Callable
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from whoopdata.analytics.data_prep import get_recovery_modeling_dataset
+
+MINUTES_PER_DAY = 24 * 60
+
+
+@dataclass(frozen=True)
+class RuleSummary:
+    rule: str
+    recommendation: str
+    feature: str
+    threshold: float
+    direction: str  # "le" or "ge"
+    days_in_rule: int
+    days_outside_rule: int
+    avg_recovery_in_rule: float
+    avg_recovery_outside_rule: float
+    green_rate_in_rule: float
+    green_rate_outside_rule: float
+    recovery_delta: float
+    green_rate_delta: float
+
+
+def _format_clock_hours(hours: float) -> str:
+    # hours can exceed 24 when using "extended" bedtime.
+    hours = hours % 24
+    hh = int(hours)
+    mm = int(round((hours - hh) * 60))
+    if mm == 60:
+        hh = (hh + 1) % 24
+        mm = 0
+    return f"{hh:02d}:{mm:02d}"
+
+
+def _bedtime_hour_extended(series_sleep_start_clock_min: pd.Series) -> pd.Series:
+    # Shift post-midnight bedtimes into the following day to preserve ordering.
+    # Same logic as notebook: treat < 12:00 as after midnight.
+    raw = series_sleep_start_clock_min
+    extended_min = raw.where(raw >= 12 * 60, raw + 24 * 60)
+    return extended_min / 60.0
+
+
+def _summarize_rule(
+    df: pd.DataFrame,
+    *,
+    mask: pd.Series,
+    rule_name: str,
+    recommendation: str,
+    feature: str,
+    threshold: float,
+    direction: str,
+    min_group_size: int,
+) -> RuleSummary | None:
+    mask = mask.fillna(False)
+    in_group = df.loc[mask]
+    out_group = df.loc[~mask]
+
+    if len(in_group) < min_group_size or len(out_group) < min_group_size:
+        return None
+
+    avg_in = float(in_group["recovery_score"].mean())
+    avg_out = float(out_group["recovery_score"].mean())
+    green_in = float(in_group["green_flag"].mean())
+    green_out = float(out_group["green_flag"].mean())
+
+    return RuleSummary(
+        rule=rule_name,
+        recommendation=recommendation,
+        feature=feature,
+        threshold=float(threshold),
+        direction=direction,
+        days_in_rule=int(len(in_group)),
+        days_outside_rule=int(len(out_group)),
+        avg_recovery_in_rule=avg_in,
+        avg_recovery_outside_rule=avg_out,
+        green_rate_in_rule=green_in,
+        green_rate_outside_rule=green_out,
+        recovery_delta=float(avg_in - avg_out),
+        green_rate_delta=float(green_in - green_out),
+    )
+
+
+def _search_threshold_rules(
+    df: pd.DataFrame,
+    *,
+    feature: str,
+    thresholds: list[float],
+    direction: str,
+    label_fmt: Callable[[float], str],
+    recommendation_fmt: Callable[[float], str],
+    min_group_size: int,
+) -> list[RuleSummary]:
+    series = df[feature]
+    out: list[RuleSummary] = []
+
+    for threshold in thresholds:
+        if direction == "le":
+            mask = series <= threshold
+        elif direction == "ge":
+            mask = series >= threshold
+        else:
+            raise ValueError(direction)
+
+        summary = _summarize_rule(
+            df,
+            mask=mask,
+            rule_name=label_fmt(threshold),
+            recommendation=recommendation_fmt(threshold),
+            feature=feature,
+            threshold=threshold,
+            direction=direction,
+            min_group_size=min_group_size,
+        )
+        if summary is not None:
+            out.append(summary)
+
+    return out
+
+
+def compute_recovery_actionability(
+    db: Session,
+    *,
+    days_back: int = 365,
+    min_group_size: int = 25,
+) -> dict[str, Any]:
+    """Compute actionability rules for recovery.
+
+    Returns a JSON-serialisable dictionary.
+    """
+    df = get_recovery_modeling_dataset(db, days_back=days_back)
+
+    payload: dict[str, Any] = {
+        "version": 1,
+        "computed_at": datetime.utcnow().isoformat(),
+        "days_back": days_back,
+        "min_group_size": min_group_size,
+        "rules": [],
+        "best_thresholds": {},
+        "notes": [],
+    }
+
+    if df is None or len(df) == 0:
+        payload["notes"].append("No recovery modeling data available")
+        return payload
+
+    required_cols = {
+        "recovery_score",
+        "sleep_hours",
+        "strain_3d_sum",
+        "sleep_start_clock_min",
+        "consecutive_sleep_deficit_days",
+    }
+    missing = sorted(c for c in required_cols if c not in df.columns)
+    if missing:
+        payload["notes"].append(f"Missing required columns: {', '.join(missing)}")
+        return payload
+
+    action_df = df.copy().sort_values("created_at").reset_index(drop=True)
+    action_df["green_flag"] = (action_df["recovery_score"] >= 67).astype(int)
+    action_df["bedtime_hour_extended"] = _bedtime_hour_extended(action_df["sleep_start_clock_min"])
+
+    bedtime_thresholds = [22.0, 22.5, 23.0, 23.5, 24.0, 24.5]
+    sleep_thresholds = [6.5, 7.0, 7.5, 8.0, 8.5]
+    streak_thresholds = [1.0, 2.0, 3.0]
+
+    # Use quantiles from the user's data for strain 3d sum thresholds.
+    strain_series = action_df["strain_3d_sum"].dropna()
+    if len(strain_series) >= max(2 * min_group_size, 50):
+        strain_thresholds = sorted(
+            {round(float(x), 1) for x in strain_series.quantile([0.5, 0.65, 0.75, 0.85]).tolist()}
+        )
+    else:
+        strain_thresholds = []
+        payload["notes"].append(
+            "Insufficient strain history to search data-driven 3-day strain thresholds"
+        )
+
+    candidates: list[RuleSummary] = []
+    candidates.extend(
+        _search_threshold_rules(
+            action_df,
+            feature="bedtime_hour_extended",
+            thresholds=bedtime_thresholds,
+            direction="le",
+            label_fmt=lambda t: f"Bedtime at or before {_format_clock_hours(t)}",
+            recommendation_fmt=lambda t: f"Aim to be asleep by about {_format_clock_hours(t)} or earlier",
+            min_group_size=min_group_size,
+        )
+    )
+    candidates.extend(
+        _search_threshold_rules(
+            action_df,
+            feature="sleep_hours",
+            thresholds=sleep_thresholds,
+            direction="ge",
+            label_fmt=lambda t: f"Sleep at least {t:.1f}h",
+            recommendation_fmt=lambda t: f"Protect at least {t:.1f}h of sleep opportunity",
+            min_group_size=min_group_size,
+        )
+    )
+    candidates.extend(
+        _search_threshold_rules(
+            action_df,
+            feature="consecutive_sleep_deficit_days",
+            thresholds=streak_thresholds,
+            direction="le",
+            label_fmt=lambda t: f"No more than {int(t)} consecutive sleep-deficit night(s)",
+            recommendation_fmt=lambda t: f"Avoid letting sleep deficit extend beyond {int(t)} consecutive night(s)",
+            min_group_size=min_group_size,
+        )
+    )
+    if strain_thresholds:
+        candidates.extend(
+            _search_threshold_rules(
+                action_df,
+                feature="strain_3d_sum",
+                thresholds=strain_thresholds,
+                direction="le",
+                label_fmt=lambda t: f"Keep 3-day strain at or below {t:.1f}",
+                recommendation_fmt=lambda t: f"Keep recent 3-day cumulative strain around {t:.1f} or lower when possible",
+                min_group_size=min_group_size,
+            )
+        )
+
+    if not candidates:
+        payload["notes"].append("No candidate rules met minimum sample size requirements")
+        return payload
+
+    # Score heuristic (same spirit as notebook): prioritize green-rate lift, then recovery lift.
+    def score(rule: RuleSummary) -> float:
+        return rule.green_rate_delta * 100.0 + rule.recovery_delta
+
+    # Best per feature.
+    by_feature: dict[str, RuleSummary] = {}
+    for rule in sorted(candidates, key=score, reverse=True):
+        by_feature.setdefault(rule.feature, rule)
+
+    best_rules = list(by_feature.values())
+    best_rules = sorted(best_rules, key=score, reverse=True)
+
+    payload["rules"] = [asdict(r) for r in best_rules]
+
+    # Extract compact thresholds we expect to surface in product surfaces.
+    best_thresholds: dict[str, Any] = {}
+    if "strain_3d_sum" in by_feature:
+        best_thresholds["strain_3d_sum_max"] = by_feature["strain_3d_sum"].threshold
+    if "bedtime_hour_extended" in by_feature:
+        best_thresholds["bedtime_before"] = _format_clock_hours(
+            by_feature["bedtime_hour_extended"].threshold
+        )
+        best_thresholds["bedtime_before_hour_extended"] = by_feature[
+            "bedtime_hour_extended"
+        ].threshold
+    payload["best_thresholds"] = best_thresholds
+
+    return payload

--- a/whoopdata/analytics/results_loader.py
+++ b/whoopdata/analytics/results_loader.py
@@ -3,8 +3,7 @@
 import json
 import sqlite3
 from pathlib import Path
-from typing import Optional, Dict
-from datetime import datetime
+from typing import Optional, Dict, Iterable
 
 
 class AnalyticsResultsLoader:
@@ -44,6 +43,33 @@ class AnalyticsResultsLoader:
             return data
 
         return None
+
+    def latest_computed_at(
+        self, *, result_types: Iterable[str], days_back: int = 365
+    ) -> Optional[str]:
+        """Return the most recent computed_at timestamp across result types.
+
+        Returned value is the raw SQLite value (typically a string).
+        """
+        result_types = list(result_types)
+        if not result_types:
+            return None
+
+        placeholders = ",".join(["?"] * len(result_types))
+        conn = sqlite3.connect(str(self.db_path))
+        cursor = conn.cursor()
+        cursor.execute(
+            f"""SELECT computed_at FROM analytics_results
+                WHERE days_back = ? AND result_type IN ({placeholders})
+                ORDER BY computed_at DESC
+                LIMIT 1""",
+            (days_back, *result_types),
+        )
+        row = cursor.fetchone()
+        conn.close()
+        if not row:
+            return None
+        return row[0]
 
     def result_exists(self, result_type: str, days_back: int = 365) -> bool:
         """Check if a result exists.

--- a/whoopdata/api/analytics_routes.py
+++ b/whoopdata/api/analytics_routes.py
@@ -5,8 +5,6 @@ Provides endpoints for factor analysis, correlations, predictions, and insights.
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-from typing import Optional
-from datetime import datetime
 
 from whoopdata.database.database import get_db
 from whoopdata.analytics.results_loader import results_loader
@@ -22,26 +20,20 @@ from whoopdata.schemas.analytics import (
     AnalyticsSummaryResponse,
     MLRModelResponse,
     CorrelationMatrixResponse,
+    RecoveryActionabilityResponse,
 )
-from whoopdata.analytics.engine import (
-    RecoveryFactorAnalyzer,
-    CorrelationAnalyzer,
-    InsightGenerator,
-    TimeSeriesAnalyzer,
-)
-from whoopdata.analytics.models import RecoveryPredictor, SleepPredictor
 from whoopdata.analytics.model_manager import model_manager
 from whoopdata.analytics.data_prep import (
     get_recovery_with_features,
-    get_sleep_with_features,
-    get_training_data,
 )
 
 insights_router = APIRouter(prefix="/api/v1/insights/analytics", tags=["insights"])
 legacy_insights_router = APIRouter(prefix="/analytics", tags=["insights"])
 
 
-@legacy_insights_router.get("/recovery/factors", response_model=FactorImportanceResponse, deprecated=True)
+@legacy_insights_router.get(
+    "/recovery/factors", response_model=FactorImportanceResponse, deprecated=True
+)
 @insights_router.get("/recovery/factors", response_model=FactorImportanceResponse)
 async def analyze_recovery_factors(
     days_back: int = Query(365, description="Days of historical data to analyze"),
@@ -115,7 +107,9 @@ async def analyze_sleep_quality_factors(
         )
 
 
-@legacy_insights_router.get("/correlations", response_model=CorrelationAnalysisResponse, deprecated=True)
+@legacy_insights_router.get(
+    "/correlations", response_model=CorrelationAnalysisResponse, deprecated=True
+)
 @insights_router.get("/correlations", response_model=CorrelationAnalysisResponse)
 async def analyze_correlations(
     days_back: int = Query(365, description="Days of historical data"),
@@ -149,7 +143,9 @@ async def analyze_correlations(
         raise HTTPException(status_code=500, detail=f"Error loading correlations: {str(e)}")
 
 
-@legacy_insights_router.post("/predict/recovery", response_model=RecoveryPredictionResponse, deprecated=True)
+@legacy_insights_router.post(
+    "/predict/recovery", response_model=RecoveryPredictionResponse, deprecated=True
+)
 @insights_router.post("/predict/recovery", response_model=RecoveryPredictionResponse)
 async def predict_recovery(request: RecoveryPredictionRequest, db: Session = Depends(get_db)):
     """Predict recovery score from input metrics using pre-trained model.
@@ -221,7 +217,9 @@ async def predict_recovery(request: RecoveryPredictionRequest, db: Session = Dep
         raise HTTPException(status_code=500, detail=f"Error predicting recovery: {str(e)}")
 
 
-@legacy_insights_router.post("/predict/sleep", response_model=SleepPredictionResponse, deprecated=True)
+@legacy_insights_router.post(
+    "/predict/sleep", response_model=SleepPredictionResponse, deprecated=True
+)
 @insights_router.post("/predict/sleep", response_model=SleepPredictionResponse)
 async def predict_sleep_performance(request: SleepPredictionRequest, db: Session = Depends(get_db)):
     """Predict sleep performance from sleep metrics using pre-trained model.
@@ -298,7 +296,9 @@ async def get_weekly_insights(
         raise HTTPException(status_code=500, detail=f"Error loading insights: {str(e)}")
 
 
-@legacy_insights_router.get("/patterns/{metric}", response_model=PatternDetectionResponse, deprecated=True)
+@legacy_insights_router.get(
+    "/patterns/{metric}", response_model=PatternDetectionResponse, deprecated=True
+)
 @insights_router.get("/patterns/{metric}", response_model=PatternDetectionResponse)
 async def analyze_metric_pattern(
     metric: str,
@@ -497,6 +497,39 @@ async def get_strain_patterns(
         raise HTTPException(status_code=500, detail=f"Error loading strain pattern data: {str(e)}")
 
 
+@insights_router.get(
+    "/recovery/actionability",
+    response_model=RecoveryActionabilityResponse,
+)
+async def get_recovery_actionability(
+    days_back: int = Query(365, description="Days of historical data"),
+):
+    """Get pre-computed recovery actionability rules.
+
+    Returns interpretable threshold-style rules (e.g. bedtime before X, keep strain under Y)
+    derived from historical patterns.
+
+    Requires the analytics pipeline to have been run.
+    """
+    try:
+        result = results_loader.load_result("recovery_actionability", days_back=days_back)
+        if result is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Recovery actionability not yet computed. Run the analytics pipeline first (option 6 in CLI).",
+            )
+
+        result.pop("_computed_at", None)
+        return RecoveryActionabilityResponse(**result)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Error loading recovery actionability: {str(e)}"
+        )
+
+
 @legacy_insights_router.get("/summary", response_model=AnalyticsSummaryResponse, deprecated=True)
 @insights_router.get("/summary", response_model=AnalyticsSummaryResponse)
 async def get_analytics_summary(
@@ -591,7 +624,9 @@ async def get_hrv_mlr(
         raise HTTPException(status_code=500, detail=f"Error loading HRV MLR: {str(e)}")
 
 
-@legacy_insights_router.get("/correlations/matrix", response_model=CorrelationMatrixResponse, deprecated=True)
+@legacy_insights_router.get(
+    "/correlations/matrix", response_model=CorrelationMatrixResponse, deprecated=True
+)
 @insights_router.get("/correlations/matrix", response_model=CorrelationMatrixResponse)
 async def get_correlation_matrix(
     days_back: int = Query(365, description="Days of historical data"),
@@ -616,6 +651,4 @@ async def get_correlation_matrix(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error loading correlation matrix: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error loading correlation matrix: {str(e)}")

--- a/whoopdata/api/app_factory.py
+++ b/whoopdata/api/app_factory.py
@@ -67,7 +67,6 @@ from whoopdata.api.workout_routes import (
     legacy_insights_router as workout_legacy_insights_router,
 )
 
-
 WEB_ROUTERS: tuple[APIRouter, ...] = (
     web_router,
     dashboard_page_router,
@@ -128,6 +127,7 @@ ROUTER_GROUPS: dict[CanonicalSurface, tuple[APIRouter, ...]] = {
     "agent": AGENT_ROUTERS,
     "web": WEB_ROUTERS,
 }
+
 
 def _build_openapi_tag_metadata() -> list[dict[str, str]]:
     tag_metadata: list[dict[str, str]] = []

--- a/whoopdata/api/daily_routes.py
+++ b/whoopdata/api/daily_routes.py
@@ -44,12 +44,12 @@ async def get_daily_plan(db: Session = Depends(get_db)):
         return await GuidanceService(db).build_daily_plan()
 
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error generating daily plan: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error generating daily plan: {str(e)}")
 
 
-@legacy_insights_router.post("/scenarios/recovery", response_model=ScenarioResponse, deprecated=True)
+@legacy_insights_router.post(
+    "/scenarios/recovery", response_model=ScenarioResponse, deprecated=True
+)
 @insights_router.post("/scenarios/recovery", response_model=ScenarioResponse)
 async def predict_scenario(request: ScenarioRequest, db: Session = Depends(get_db)):
     """Predict recovery for a hypothetical scenario.
@@ -68,9 +68,7 @@ async def predict_scenario(request: ScenarioRequest, db: Session = Depends(get_d
     except ValueError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error predicting scenario: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error predicting scenario: {str(e)}")
 
 
 @legacy_insights_router.post("/scenarios/compare", response_model=CompareResponse, deprecated=True)
@@ -91,9 +89,7 @@ async def compare_scenarios(request: CompareRequest, db: Session = Depends(get_d
     except ValueError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error comparing scenarios: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error comparing scenarios: {str(e)}")
 
 
 @legacy_insights_router.get("/reports/weekly", deprecated=True)
@@ -114,6 +110,4 @@ async def get_weekly_coaching_report(
         return GuidanceService(db).get_weekly_coaching_report(weeks=weeks)
 
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Error generating coaching report: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Error generating coaching report: {str(e)}")

--- a/whoopdata/api/dashboard_page_routes.py
+++ b/whoopdata/api/dashboard_page_routes.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 
-
 router = APIRouter(prefix="/dashboard", include_in_schema=False)
 templates = Jinja2Templates(directory="templates")
 

--- a/whoopdata/api/dashboard_routes.py
+++ b/whoopdata/api/dashboard_routes.py
@@ -11,6 +11,7 @@ from whoopdata.services.insight_context_service import DEFAULT_LOCATION
 insights_router = APIRouter(prefix="/api/v1/insights/dashboard", tags=["insights"])
 legacy_insights_router = APIRouter(prefix="/dashboard", tags=["insights"])
 
+
 @legacy_insights_router.get("/daily", deprecated=True)
 @insights_router.get("/daily")
 async def get_daily_dashboard(

--- a/whoopdata/api/legacy_route_deprecation.py
+++ b/whoopdata/api/legacy_route_deprecation.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
-from fastapi.routing import APIRoute
 from starlette.responses import PlainTextResponse
 
 from whoopdata.api.public_surface_contract import (
@@ -39,7 +38,7 @@ LEGACY_ROUTE_RESPONSE_HEADERS: dict[str, dict[str, Any]] = {
         "schema": {"type": "string"},
     },
     "Link": {
-        "description": f"Canonical replacement route advertised with rel=\"{SUCCESSOR_VERSION_REL}\".",
+        "description": f'Canonical replacement route advertised with rel="{SUCCESSOR_VERSION_REL}".',
         "schema": {"type": "string"},
     },
     "X-Canonical-Route": {

--- a/whoopdata/api/public_response_contract.py
+++ b/whoopdata/api/public_response_contract.py
@@ -75,9 +75,7 @@ PUBLIC_RESPONSE_CONTRACT: dict[CanonicalSurface, SurfaceResponseContract] = {
     "web": SurfaceResponseContract(
         surface="web",
         summary="HTML page shells that consume the API surfaces rather than defining an API response contract of their own.",
-        primary_shapes=(
-            "server-rendered HTML page",
-        ),
+        primary_shapes=("server-rendered HTML page",),
         invariants=(
             "Web routes remain page shells and should not become parallel JSON product surfaces.",
             "Page code may compose multiple data and insight contracts, but the page itself is not part of the API response surface.",

--- a/whoopdata/api/public_surface_contract.py
+++ b/whoopdata/api/public_surface_contract.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Literal
 
-
 CanonicalSurface = Literal["data", "insights", "agent", "web"]
 RouteKind = Literal["api", "page"]
 RouteRole = Literal[

--- a/whoopdata/api/public_surface_inventory.py
+++ b/whoopdata/api/public_surface_inventory.py
@@ -194,6 +194,16 @@ AGENT_ROUTE_MIGRATION_MATRIX: tuple[RouteMigrationEntry, ...] = (
         current_role="conversation",
         notes="Canonical public route for submitting user messages through the shared conversation boundary.",
     ),
+    route(
+        "/api/v1/agent/telegram/push",
+        methods=("POST",),
+        handler_names=("telegram_push",),
+        source_refs=("whoopdata/api/agent_routes.py:57-84",),
+        canonical_surface="agent",
+        target_path="/api/v1/agent/telegram/push",
+        current_role="conversation",
+        notes="Canonical public route for proactive Telegram pushes through the shared conversation boundary.",
+    ),
 )
 
 
@@ -753,6 +763,14 @@ INSIGHT_ROUTE_MIGRATION_MATRIX: tuple[RouteMigrationEntry, ...] = (
         current_role="derived_output",
     ),
     route(
+        "/api/v1/insights/analytics/recovery/actionability",
+        handler_names=("get_recovery_actionability",),
+        source_refs=("whoopdata/api/analytics_routes.py:500-533",),
+        canonical_surface="insights",
+        target_path="/api/v1/insights/analytics/recovery/actionability",
+        current_role="derived_output",
+    ),
+    route(
         "/api/v1/insights/tides/forecast",
         handler_names=("get_tide_forecast",),
         source_refs=("whoopdata/api/tide_routes.py:73-108",),
@@ -1149,6 +1167,15 @@ ENTRYPOINT_MIGRATION_MATRIX: tuple[EntrypointMigrationEntry, ...] = (
         current_role="provider_auth",
         primary_surface="data",
         target="Canonical provider-auth utility for the Withings integration.",
+        migration_action="keep_primary",
+    ),
+    entrypoint(
+        "whoop-telegram-bot",
+        kind="project_script",
+        source_refs=("pyproject.toml:90-94", "whoopdata/telegram_bot.py:1-999"),
+        current_role="chat_ui",
+        primary_surface="agent",
+        target="Canonical Telegram bot runtime backed by the shared /api/v1/agent/* conversation boundary.",
         migration_action="keep_primary",
     ),
     entrypoint(

--- a/whoopdata/api/recovery_routes.py
+++ b/whoopdata/api/recovery_routes.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List, Optional, Union
 from whoopdata.schemas.recovery import Recovery as RecoverySchema, AvgRecovery
 from whoopdata.crud.recovery import get_recoveries, get_top_recoveries, get_avg_recovery_by_week
-from whoopdata.utils.date_filters import standardize_date_params, apply_recovery_date_filter
+from whoopdata.utils.date_filters import standardize_date_params
 from whoopdata.database.database import get_db
 
 data_router = APIRouter(prefix="/api/v1/data", tags=["data"])
@@ -12,7 +12,9 @@ insights_router = APIRouter(prefix="/api/v1/insights", tags=["insights"])
 legacy_insights_router = APIRouter(tags=["insights"])
 
 
-@legacy_data_router.get("/recovery", response_model=Union[List[RecoverySchema], RecoverySchema], deprecated=True)
+@legacy_data_router.get(
+    "/recovery", response_model=Union[List[RecoverySchema], RecoverySchema], deprecated=True
+)
 @data_router.get("/recovery", response_model=Union[List[RecoverySchema], RecoverySchema])
 def get_recovery_data(
     latest: bool = Query(False, description="Get only the latest record"),
@@ -62,7 +64,9 @@ def get_recovery_data(
         raise HTTPException(status_code=500, detail=f"Error retrieving recovery data: {str(e)}")
 
 
-@legacy_insights_router.get("/recovery/analytics/weekly", response_model=List[AvgRecovery], deprecated=True)
+@legacy_insights_router.get(
+    "/recovery/analytics/weekly", response_model=List[AvgRecovery], deprecated=True
+)
 @insights_router.get("/recovery/analytics/weekly", response_model=List[AvgRecovery])
 def get_recovery_weekly_analytics(
     weeks: int = Query(4, description="Number of weeks to analyze (can be 52+ for full year)"),
@@ -109,7 +113,9 @@ def top_recoveries_compat(limit: int = 10, db: Session = Depends(get_db)):
     return get_top_recoveries(db, limit=limit)
 
 
-@legacy_insights_router.get("/recoveries/avg_recoveries/", response_model=List[AvgRecovery], deprecated=True)
+@legacy_insights_router.get(
+    "/recoveries/avg_recoveries/", response_model=List[AvgRecovery], deprecated=True
+)
 def avg_recovery_compat(week: int = 4, db: Session = Depends(get_db)):
     """Backward compatibility endpoint - redirects to analytics endpoint."""
     return get_avg_recovery_by_week(db, weeks=week)

--- a/whoopdata/api/sleep_routes.py
+++ b/whoopdata/api/sleep_routes.py
@@ -10,7 +10,9 @@ data_router = APIRouter(prefix="/api/v1/data", tags=["data"])
 legacy_data_router = APIRouter(tags=["data"])
 
 
-@legacy_data_router.get("/sleep", response_model=Union[List[SleepSchema], SleepSchema], deprecated=True)
+@legacy_data_router.get(
+    "/sleep", response_model=Union[List[SleepSchema], SleepSchema], deprecated=True
+)
 @data_router.get("/sleep", response_model=Union[List[SleepSchema], SleepSchema])
 def get_sleep_data(
     latest: bool = Query(False, description="Get only the latest record"),

--- a/whoopdata/api/tide_routes.py
+++ b/whoopdata/api/tide_routes.py
@@ -1,5 +1,5 @@
 """Thames tide API routes."""
-from typing import Optional
+
 
 from fastapi import APIRouter, HTTPException
 
@@ -19,7 +19,7 @@ tide_service = TideService()
 @data_router.get("/stations")
 async def list_stations() -> dict:
     """List available tidal monitoring stations in East London.
-    
+
     Returns:
         Dictionary of station names and IDs
     """
@@ -49,24 +49,24 @@ async def list_stations() -> dict:
 @data_router.get("/current", response_model=TideReading)
 async def get_current_tide(station: str = "0001") -> TideReading:
     """Get the current tide level for a station.
-    
+
     Args:
         station: Station ID (default: 0001 = Silvertown)
-        
+
     Returns:
         Current tide reading
-        
+
     Raises:
         HTTPException: If station data unavailable
     """
     reading = await tide_service.get_latest_reading(station)
-    
+
     if reading is None:
         raise HTTPException(
             status_code=404,
             detail=f"Failed to retrieve tide data for station {station}",
         )
-    
+
     return reading
 
 
@@ -77,17 +77,17 @@ async def get_tide_forecast(
     hours: int = 24,
 ) -> TideForecast:
     """Get tide forecast with predicted high/low tides.
-    
+
     Uses harmonic analysis of past 24h data to predict
     tides for the next N hours.
-    
+
     Args:
         station: Station ID (default: 0001 = Silvertown)
         hours: Hours to forecast ahead (default: 24, max: 72)
-        
+
     Returns:
         Tide forecast with high/low tide predictions
-        
+
     Raises:
         HTTPException: If forecast generation fails
     """
@@ -96,15 +96,15 @@ async def get_tide_forecast(
             status_code=400,
             detail="Forecast hours cannot exceed 72",
         )
-    
+
     forecast = await tide_service.get_tide_forecast(station, hours_ahead=hours)
-    
+
     if not forecast.high_tides and not forecast.low_tides:
         raise HTTPException(
             status_code=503,
             detail="Insufficient data to generate forecast",
         )
-    
+
     return forecast
 
 
@@ -112,21 +112,21 @@ async def get_tide_forecast(
 @insights_router.get("/stats")
 async def get_tidal_statistics(station: str = "0001") -> dict:
     """Get tidal range statistics for the past 24 hours.
-    
+
     Args:
         station: Station ID (default: 0001 = Silvertown)
-        
+
     Returns:
         Dictionary with min, max, range, and mean values
     """
     stats = await tide_service.calculate_tidal_range(station)
-    
+
     if stats["min"] is None:
         raise HTTPException(
             status_code=404,
             detail=f"Failed to calculate statistics for station {station}",
         )
-    
+
     return {
         "station_id": station,
         "period_hours": 24,
@@ -141,20 +141,20 @@ async def get_optimal_walk_times(
     days: int = 3,
 ) -> dict:
     """Get 'perfect walk hotspots' - optimal times for Thames walks.
-    
+
     Scores times based on:
     - High tide at sunset/sunrise (+3 points)
     - Clear skies <25% clouds (+2 points)
     - Low wind <10 mph (+1 point)
     - Comfortable temp 10-20°C (+1 point)
-    
+
     Args:
         station: Station ID (default: 0001 = Silvertown)
         days: Days to analyze (default: 3, max: 5)
-        
+
     Returns:
         List of optimal walk times with scores and conditions
-        
+
     Raises:
         HTTPException: If hotspot calculation fails
     """
@@ -163,19 +163,19 @@ async def get_optimal_walk_times(
             status_code=400,
             detail="Days cannot exceed 5",
         )
-    
+
     # Get weather forecast for hotspot calculation
     try:
         from whoopdata.services.weather_service import WeatherAPI
-        
+
         weather_service = WeatherAPI()
-        
+
         # Get Silvertown coordinates (approximate)
         coords = {"lat": 51.4975, "lon": 0.0526}
-        
+
         # Get hourly forecast
         forecast = weather_service.get_forecast(coords["lat"], coords["lon"])
-        
+
         # Convert to expected format for hotspot calculation
         weather_data = {
             "hourly": [
@@ -188,13 +188,13 @@ async def get_optimal_walk_times(
                 for f in forecast.get("forecast", [])
             ]
         }
-        
+
         hotspots = await tide_service.calculate_perfect_walk_hotspots(
             weather_data=weather_data,
             station_id=station,
             days_ahead=days,
         )
-        
+
         return {
             "station_id": station,
             "days_analyzed": days,
@@ -209,8 +209,8 @@ async def get_optimal_walk_times(
                 for spot in hotspots
             ],
         }
-        
-    except ValueError as e:
+
+    except ValueError:
         # WeatherAPI init failed (missing API key)
         raise HTTPException(
             status_code=503,
@@ -227,22 +227,22 @@ async def get_optimal_walk_times(
 @data_router.get("/station/{station_id}", response_model=TideStation)
 async def get_station_info(station_id: str) -> TideStation:
     """Get metadata for a tidal monitoring station.
-    
+
     Args:
         station_id: Station ID (e.g. "0001" for Silvertown)
-        
+
     Returns:
         Station metadata
-        
+
     Raises:
         HTTPException: If station not found
     """
     station = await tide_service.get_station_data(station_id)
-    
+
     if station is None:
         raise HTTPException(
             status_code=404,
             detail=f"Station {station_id} not found",
         )
-    
+
     return station

--- a/whoopdata/api/web_routes.py
+++ b/whoopdata/api/web_routes.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Request
 from fastapi.templating import Jinja2Templates
 
-
 router = APIRouter(include_in_schema=False)
 templates = Jinja2Templates(directory="templates")
 

--- a/whoopdata/api/withings_routes.py
+++ b/whoopdata/api/withings_routes.py
@@ -4,7 +4,6 @@ from whoopdata.database.database import get_db
 from whoopdata.models.models import WithingsWeight, WithingsHeartRate
 from typing import List, Optional, Union
 from datetime import datetime, timedelta
-import pandas as pd
 
 data_router = APIRouter(prefix="/api/v1/data", tags=["data"])
 legacy_data_router = APIRouter(tags=["data"])
@@ -203,7 +202,9 @@ async def get_weight_stats(
         raise HTTPException(status_code=500, detail=f"Error calculating weight stats: {str(e)}")
 
 
-@legacy_data_router.get("/withings/heart-rate", response_model=Union[List[dict], dict], deprecated=True)
+@legacy_data_router.get(
+    "/withings/heart-rate", response_model=Union[List[dict], dict], deprecated=True
+)
 @data_router.get("/withings/heart-rate", response_model=Union[List[dict], dict])
 async def get_heart_rate_data(
     latest: bool = Query(False, description="Get only the latest record"),
@@ -379,7 +380,6 @@ async def get_withings_summary(
 # ============================================================================
 
 
-
 @legacy_insights_router.get("/withings/weight/stats", deprecated=True)
 async def get_weight_stats_compat(
     db: Session = Depends(get_db),
@@ -434,5 +434,3 @@ async def get_weight_stats_compat(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error calculating weight stats: {str(e)}")
-
-

--- a/whoopdata/api/withings_status_routes.py
+++ b/whoopdata/api/withings_status_routes.py
@@ -4,7 +4,6 @@ from whoopdata.clients.withings_client import WithingsClient
 from whoopdata.database.database import SessionLocal
 from whoopdata.models.models import WithingsHeartRate, WithingsWeight
 
-
 data_router = APIRouter(prefix="/api/v1/data", tags=["data"])
 legacy_data_router = APIRouter(tags=["data"])
 

--- a/whoopdata/api/workout_routes.py
+++ b/whoopdata/api/workout_routes.py
@@ -34,7 +34,9 @@ def calculate_trimp_from_run(run) -> float:
     return trimp
 
 
-@legacy_data_router.get("/workouts", response_model=Union[List[WorkoutSchema], WorkoutSchema], deprecated=True)
+@legacy_data_router.get(
+    "/workouts", response_model=Union[List[WorkoutSchema], WorkoutSchema], deprecated=True
+)
 @data_router.get("/workouts", response_model=Union[List[WorkoutSchema], WorkoutSchema])
 def get_workout_data(
     latest: bool = Query(False, description="Get only the latest record"),
@@ -84,7 +86,9 @@ def get_workout_data(
         raise HTTPException(status_code=500, detail=f"Error retrieving workout data: {str(e)}")
 
 
-@legacy_data_router.get("/workouts/types/running", response_model=List[WorkoutSchema], deprecated=True)
+@legacy_data_router.get(
+    "/workouts/types/running", response_model=List[WorkoutSchema], deprecated=True
+)
 @data_router.get("/workouts/types/running", response_model=List[WorkoutSchema])
 def get_running_workouts(
     limit: int = Query(
@@ -122,7 +126,9 @@ def get_running_workouts(
         raise HTTPException(status_code=500, detail=f"Error retrieving running workouts: {str(e)}")
 
 
-@legacy_data_router.get("/workouts/types/tennis", response_model=List[WorkoutSchema], deprecated=True)
+@legacy_data_router.get(
+    "/workouts/types/tennis", response_model=List[WorkoutSchema], deprecated=True
+)
 @data_router.get("/workouts/types/tennis", response_model=List[WorkoutSchema])
 def get_tennis_workouts(
     limit: int = Query(
@@ -160,7 +166,9 @@ def get_tennis_workouts(
         raise HTTPException(status_code=500, detail=f"Error retrieving tennis workouts: {str(e)}")
 
 
-@legacy_insights_router.get("/workouts/analytics/trimp", response_model=List[WorkoutSchema], deprecated=True)
+@legacy_insights_router.get(
+    "/workouts/analytics/trimp", response_model=List[WorkoutSchema], deprecated=True
+)
 @insights_router.get("/workouts/analytics/trimp", response_model=List[WorkoutSchema])
 def get_running_workouts_with_trimp(
     limit: int = Query(100, description="Maximum number of records"),
@@ -215,7 +223,9 @@ def list_runs_compat(skip: int = 0, limit: int = 10, db: Session = Depends(get_d
     return get_runs(db, skip=skip, limit=limit)
 
 
-@legacy_insights_router.get("/workouts/get_run_trimp", response_model=List[WorkoutSchema], deprecated=True)
+@legacy_insights_router.get(
+    "/workouts/get_run_trimp", response_model=List[WorkoutSchema], deprecated=True
+)
 def list_trimp_scores_compat(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
     """Backward compatibility endpoint - redirects to analytics endpoint."""
     runs_list = get_runs(db, skip=skip, limit=limit)

--- a/whoopdata/cli.py
+++ b/whoopdata/cli.py
@@ -9,8 +9,6 @@ Complete Health Data Application Launcher
 import os
 import sys
 import subprocess
-import time
-from pathlib import Path
 
 # Add current directory to path
 sys.path.append(os.path.abspath("."))
@@ -68,9 +66,7 @@ def check_dependencies():
         )
         console.print(
             "💡 Install with: pip install "
-            + " ".join(
-                "scikit-learn" if pkg == "sklearn" else pkg for pkg in missing_analytics
-            )
+            + " ".join("scikit-learn" if pkg == "sklearn" else pkg for pkg in missing_analytics)
         )
     else:
         console.print("✅ [bold green]Analytics dependencies found[/bold green]")
@@ -139,7 +135,7 @@ def run_data_pipeline(incremental=True):
         total_success = sum(stats["success"] for stats in results.values())
         total_errors = sum(stats["errors"] for stats in results.values())
 
-        console.print(f"\n🎉 [bold green]Data Pipeline Complete![/bold green]")
+        console.print("\n🎉 [bold green]Data Pipeline Complete![/bold green]")
         console.print(f"📈 Records loaded: {total_success}")
         console.print(f"❌ Errors: {total_errors}")
 
@@ -187,7 +183,7 @@ def show_available_endpoints():
 
     console.print(table)
 
-    console.print(f"\n💡 [bold]Quick test URLs:[/bold]")
+    console.print("\n💡 [bold]Quick test URLs:[/bold]")
     console.print("   • Latest recovery: http://localhost:8000/recovery/latest")
     console.print("   • Latest weight: http://localhost:8000/withings/weight/latest")
     console.print("   • API docs: http://localhost:8000/docs")
@@ -270,6 +266,7 @@ def withings_auth_main():
     except Exception as e:
         print(f"❌ Re-authentication failed: {e}")
         return 1
+
 
 def main():
     """Main application launcher"""

--- a/whoopdata/clients/whoop_client.py
+++ b/whoopdata/clients/whoop_client.py
@@ -1,4 +1,3 @@
-import numpy as np
 import requests
 import logging
 import pandas as pd

--- a/whoopdata/clients/withings_client.py
+++ b/whoopdata/clients/withings_client.py
@@ -272,13 +272,15 @@ class WithingsClient:
 
         auth_url = f"{self.AUTH_URL}?" + urllib.parse.urlencode(auth_params)
 
-        print(f"\n🌐 Please visit this URL to authorize the Withings application:")
+        print("\n🌐 Please visit this URL to authorize the Withings application:")
         print(f"🔗 {auth_url}")
         print("🌐 Opening browser...")
         try:
             opened = webbrowser.open(auth_url)
             if not opened:
-                print("⚠️ Could not open browser automatically. Copy the URL above into your browser.")
+                print(
+                    "⚠️ Could not open browser automatically. Copy the URL above into your browser."
+                )
         except Exception:
             print("⚠️ Could not open browser automatically. Copy the URL above into your browser.")
 

--- a/whoopdata/crud/sleep.py
+++ b/whoopdata/crud/sleep.py
@@ -1,6 +1,4 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import func
-from datetime import datetime, timedelta
 from whoopdata.models.models import Sleep
 
 

--- a/whoopdata/crud/workout.py
+++ b/whoopdata/crud/workout.py
@@ -1,6 +1,5 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import func
-from datetime import datetime, timedelta
+from datetime import datetime
 from whoopdata.models.models import Workout
 from typing import Optional
 

--- a/whoopdata/database/analytics_schema.py
+++ b/whoopdata/database/analytics_schema.py
@@ -14,8 +14,7 @@ def create_analytics_results_table():
     conn = sqlite3.connect(str(db_path))
     cursor = conn.cursor()
 
-    cursor.execute(
-        """
+    cursor.execute("""
         CREATE TABLE IF NOT EXISTS analytics_results (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             result_type TEXT NOT NULL,
@@ -24,16 +23,13 @@ def create_analytics_results_table():
             days_back INTEGER,
             UNIQUE(result_type, days_back)
         )
-    """
-    )
+    """)
 
     # Create index for faster lookups
-    cursor.execute(
-        """
+    cursor.execute("""
         CREATE INDEX IF NOT EXISTS idx_result_type 
         ON analytics_results(result_type)
-    """
-    )
+    """)
 
     conn.commit()
     conn.close()

--- a/whoopdata/etl.py
+++ b/whoopdata/etl.py
@@ -4,12 +4,10 @@ Combined Extract-Transform-Load script for WHOOP and Withings data
 Seamless setup and data pipeline for both health platforms
 """
 
-from sqlalchemy.orm import sessionmaker
 from whoopdata.analysis.whoop_client import Whoop
 from whoopdata.clients.withings_client import WithingsClient
 from whoopdata.models.models import (
     Recovery,
-    Cycle,
     Workout,
     Sleep,
     WithingsWeight,
@@ -22,16 +20,13 @@ from whoopdata.model_transformation import (
     transform_recovery,
     transform_cycle,
     transform_workout,
-    transform_withings_weight,
-    transform_withings_heart_rate,
 )
 import sys
 import os
-from rich import print as rich_print
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
-from whoopdata.database.database import SessionLocal, engine
+from whoopdata.database.database import SessionLocal
 
 console = Console()
 
@@ -314,6 +309,7 @@ def withings_etl_run(data_type="weight", limit=None, startdate=None, enddate=Non
         # Log recency diagnostic
         try:
             from whoopdata.models.models import WithingsWeight, WithingsHeartRate
+
             latest_db_dt = None
             if data_type == "weight":
                 rec = (
@@ -387,7 +383,6 @@ def run_complete_etl(incremental=True):
     console.print("\n" + "=" * 60)
     console.print("[bold cyan]WHOOP Data Pipeline[/bold cyan]")
     console.print("=" * 60)
-
 
     # Sleep
     sleep_start, sleep_end = windows.get("sleep", (None, None))
@@ -535,7 +530,7 @@ def show_sample_data():
         sleep_count = db.query(Sleep).count()
         hr_count = db.query(WithingsHeartRate).count()
 
-        console.print(f"\n📊 [bold]Database Summary:[/bold]")
+        console.print("\n📊 [bold]Database Summary:[/bold]")
         console.print(f"   • Recovery Records: {recovery_count}")
         console.print(f"   • Workout Records: {workout_count}")
         console.print(f"   • Sleep Records: {sleep_count}")

--- a/whoopdata/etl_incremental.py
+++ b/whoopdata/etl_incremental.py
@@ -8,7 +8,14 @@ recent data from WHOOP and Withings APIs, making daily ETL runs much faster.
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Tuple
 from sqlalchemy.orm import Session
-from whoopdata.models.models import Recovery, Sleep, Workout, Cycle, WithingsWeight, WithingsHeartRate
+from whoopdata.models.models import (
+    Recovery,
+    Sleep,
+    Workout,
+    Cycle,
+    WithingsWeight,
+    WithingsHeartRate,
+)
 
 
 def get_latest_timestamps(db: Session) -> Dict[str, Optional[datetime]]:

--- a/whoopdata/models/models.py
+++ b/whoopdata/models/models.py
@@ -259,3 +259,19 @@ class RecommendationOutcome(Base):
     recorded_at = Column(DateTime, default=datetime.utcnow)
 
     recommendation = relationship("Recommendation", back_populates="outcomes")
+
+
+class ProactiveMessageLog(Base):
+    """Tracks proactive nudges so the planner can apply cooldowns and escalation."""
+    __tablename__ = "proactive_message_log"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    chat_id = Column(Integer, nullable=False)
+    mode = Column(String, nullable=False)
+    intent = Column(String, nullable=False)
+    trigger_fingerprint = Column(String)
+    reason = Column(String)
+    evidence_json = Column(String)
+    prompt = Column(String, nullable=False)
+    telegram_message_id = Column(Integer)
+    sent_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/whoopdata/pipelines/analytics_pipeline.py
+++ b/whoopdata/pipelines/analytics_pipeline.py
@@ -25,10 +25,10 @@ from whoopdata.analytics.engine import (
 from whoopdata.analytics.data_prep import (
     get_recovery_modeling_dataset,
     get_recovery_with_features,
-    get_sleep_with_features,
     get_sleep_quality_features,
     get_training_data,
 )
+from whoopdata.analytics.recovery_actionability import compute_recovery_actionability
 from whoopdata.analytics.mlr import (
     prepare_recovery_mlr_data,
     fit_recovery_mlr_model,
@@ -81,7 +81,7 @@ class AnalyticsPipeline:
             self._train_factor_analyzer(progress, task1)
 
             # Step 2: Compute analytics
-            task2 = progress.add_task("Computing analytics...", total=11)
+            task2 = progress.add_task("Computing analytics...", total=12)
 
             self._compute_factor_importance(progress, task2)
             self._compute_sleep_factors(progress, task2)
@@ -92,6 +92,7 @@ class AnalyticsPipeline:
             self._compute_correlation_matrix(progress, task2)
             self._compute_insights(progress, task2)
             self._compute_trends(progress, task2)
+            self._compute_recovery_actionability(progress, task2)
             self._compute_summary(progress, task2)
 
             progress.update(task2, advance=1)
@@ -625,6 +626,25 @@ class AnalyticsPipeline:
 
         progress.update(task_id, advance=1)
 
+    def _compute_recovery_actionability(self, progress, task_id):
+        """Compute and save recovery actionability rules."""
+        try:
+            console.print("[cyan]  🔄 Computing Recovery Actionability...[/cyan]")
+
+            db = SessionLocal()
+            result = compute_recovery_actionability(db, days_back=self.days_back)
+            db.close()
+
+            self._save_result("recovery_actionability", result)
+            self.results["analytics_computed"].append("recovery_actionability")
+            console.print("[green]    ✅ Recovery Actionability computed[/green]")
+
+        except Exception as e:
+            self.results["errors"].append(f"Recovery Actionability: {str(e)}")
+            console.print(f"[red]    ❌ Error: {str(e)}[/red]")
+
+        progress.update(task_id, advance=1)
+
     def _compute_summary(self, progress, task_id):
         """Generate and save analytics summary."""
         try:
@@ -707,7 +727,7 @@ class AnalyticsPipeline:
                 console.print(f"  • {model['model']}: R² = {model['accuracy']:.3f}")
 
         if self.results["analytics_computed"]:
-            console.print(f"\n[bold]📊 Analytics Computed:[/bold]")
+            console.print("\n[bold]📊 Analytics Computed:[/bold]")
             for analysis in self.results["analytics_computed"]:
                 console.print(f"  • {analysis}")
 
@@ -716,7 +736,7 @@ class AnalyticsPipeline:
             for error in self.results["errors"]:
                 console.print(f"  • {error}")
 
-        console.print(f"\n[dim]Results stored in database and ready for API queries[/dim]")
+        console.print("\n[dim]Results stored in database and ready for API queries[/dim]")
 
 
 def run_analytics_pipeline(days_back: int = 365):

--- a/whoopdata/schemas/analytics.py
+++ b/whoopdata/schemas/analytics.py
@@ -170,3 +170,35 @@ class CorrelationMatrixResponse(BaseModel):
 
     features: List[str]
     matrix: List[List[float]]
+
+
+# =================== Recovery Actionability Schemas ===================
+
+
+class RecoveryActionabilityRule(BaseModel):
+    rule: str
+    recommendation: str
+    feature: str
+    threshold: float
+    direction: str
+
+    days_in_rule: int
+    days_outside_rule: int
+
+    avg_recovery_in_rule: float
+    avg_recovery_outside_rule: float
+    green_rate_in_rule: float
+    green_rate_outside_rule: float
+
+    recovery_delta: float
+    green_rate_delta: float
+
+
+class RecoveryActionabilityResponse(BaseModel):
+    version: int
+    computed_at: datetime
+    days_back: int
+    min_group_size: int
+    rules: List[RecoveryActionabilityRule]
+    best_thresholds: Dict[str, float | str]
+    notes: List[str]

--- a/whoopdata/schemas/daily.py
+++ b/whoopdata/schemas/daily.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Optional
 from datetime import datetime
 
-
 # =================== Daily Action Card ===================
 
 

--- a/whoopdata/schemas/sleep.py
+++ b/whoopdata/schemas/sleep.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from typing import Optional
 from datetime import datetime
 
 

--- a/whoopdata/schemas/workout.py
+++ b/whoopdata/schemas/workout.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, field_serializer, Field, computed_field
+from pydantic import BaseModel, computed_field
 from typing import Optional
 from datetime import datetime
 
@@ -28,6 +28,7 @@ class Workouts(BaseModel):
     def sport_name(self) -> str:
         """Get human-readable sport name from sport_id."""
         from whoopdata.utils.sport_mapping import get_sport_name
+
         return get_sport_name(self.sport_id)
 
     @computed_field
@@ -35,6 +36,7 @@ class Workouts(BaseModel):
     def sport_category(self) -> str:
         """Get sport category (Cardio, Strength, etc.)."""
         from whoopdata.utils.sport_mapping import get_sport_category
+
         return get_sport_category(self.sport_id)
 
     class Config:

--- a/whoopdata/services/adherence_tracker.py
+++ b/whoopdata/services/adherence_tracker.py
@@ -81,14 +81,16 @@ class AdherenceTracker:
             outcome = self._check_recommendation(rec, actual_data)
             if outcome:
                 self.db.add(outcome)
-                results.append({
-                    "recommendation": rec.action_text,
-                    "category": rec.category,
-                    "followed": outcome.followed,
-                    "actual_value": outcome.actual_value,
-                    "target_value": rec.target_value,
-                    "recovery_score": outcome.recovery_score,
-                })
+                results.append(
+                    {
+                        "recommendation": rec.action_text,
+                        "category": rec.category,
+                        "followed": outcome.followed,
+                        "actual_value": outcome.actual_value,
+                        "target_value": rec.target_value,
+                        "recovery_score": outcome.recovery_score,
+                    }
+                )
 
         self.db.commit()
         return results

--- a/whoopdata/services/daily_engine.py
+++ b/whoopdata/services/daily_engine.py
@@ -17,7 +17,6 @@ from sqlalchemy.orm import Session
 
 from whoopdata.crud.recovery import get_recoveries
 from whoopdata.crud.sleep import get_sleep
-from whoopdata.analytics.model_manager import model_manager
 from whoopdata.analytics.data_prep import get_recovery_with_features
 from whoopdata.analytics.results_loader import results_loader
 from whoopdata.schemas.daily import (
@@ -79,6 +78,9 @@ class DailyEngine:
 
         # Build sleep target from historical patterns
         sleep_target = self._build_sleep_target(sleep_patterns, baselines)
+
+        # Optionally augment with persisted recovery actionability thresholds.
+        sleep_target = self._inject_actionability_thresholds(sleep_target)
 
         # Build context summary
         context = self._build_context(weather_data, transport_data, tide_data)
@@ -462,9 +464,7 @@ class DailyEngine:
             # Adjust to 30-min precision
             bedtime_str = f"{optimal_bedtime_hour:02d}:30"
 
-        reasoning_parts = [
-            f"Your best recoveries come with {optimal_hours:.1f}+ hours of sleep"
-        ]
+        reasoning_parts = [f"Your best recoveries come with {optimal_hours:.1f}+ hours of sleep"]
         if optimal_efficiency and optimal_efficiency > 80:
             reasoning_parts.append(f"at {optimal_efficiency:.0f}%+ efficiency")
 
@@ -473,6 +473,41 @@ class DailyEngine:
             target_hours=optimal_hours,
             reasoning=". ".join(reasoning_parts) + ".",
         )
+
+    def _inject_actionability_thresholds(self, sleep_target: SleepTarget) -> SleepTarget:
+        """Add strain/bedtime thresholds to the plan when available.
+
+        Keeps output compact by appending a single sentence to sleep_target.reasoning.
+        """
+        try:
+            result = results_loader.load_result("recovery_actionability", days_back=365)
+            if not result:
+                return sleep_target
+
+            best = result.get("best_thresholds") or {}
+            strain_max = best.get("strain_3d_sum_max")
+            bedtime_before = best.get("bedtime_before")
+
+            parts = []
+            if strain_max is not None:
+                try:
+                    parts.append(f"keep recent 3-day strain ≤ {float(strain_max):.1f}")
+                except Exception:
+                    pass
+            if bedtime_before:
+                parts.append(f"bedtime by ~{bedtime_before}")
+
+            if not parts:
+                return sleep_target
+
+            extra = "To target green tomorrow: " + " and ".join(parts) + "."
+            return SleepTarget(
+                target_bedtime=sleep_target.target_bedtime,
+                target_hours=sleep_target.target_hours,
+                reasoning=(sleep_target.reasoning.rstrip(".") + ". " + extra),
+            )
+        except Exception:
+            return sleep_target
 
     # =================== Context ===================
 
@@ -513,11 +548,14 @@ class DailyEngine:
         if transport_data and not transport_data.get("error"):
             lines = transport_data if isinstance(transport_data, list) else []
             disrupted = [
-                line for line in lines
+                line
+                for line in lines
                 if isinstance(line, dict) and line.get("status", "").lower() != "good service"
             ]
             if disrupted:
-                issues = [f"{l.get('name', 'Line')}: {l.get('status', 'disrupted')}" for l in disrupted]
+                issues = [
+                    f"{l.get('name', 'Line')}: {l.get('status', 'disrupted')}" for l in disrupted
+                ]
                 transport_str = "; ".join(issues)
             elif lines:
                 transport_str = "All lines running normally"
@@ -532,9 +570,7 @@ class DailyEngine:
             outdoor_window=outdoor_window,
         )
 
-    def _compute_outdoor_window(
-        self, weather_data: Dict, tide_data: Dict
-    ) -> Optional[str]:
+    def _compute_outdoor_window(self, weather_data: Dict, tide_data: Dict) -> Optional[str]:
         """Find best outdoor activity window from weather and tide data."""
         # Simple heuristic: use sunrise/sunset from weather if available
         current = weather_data.get("current", {})

--- a/whoopdata/services/dashboard_service.py
+++ b/whoopdata/services/dashboard_service.py
@@ -41,7 +41,9 @@ class DashboardService:
         }
 
         try:
-            dashboard_data["context"]["weather"] = self.context_service.get_weather_summary(location)
+            dashboard_data["context"]["weather"] = self.context_service.get_weather_summary(
+                location
+            )
         except Exception as e:
             dashboard_data["context"]["weather"] = {"error": str(e)}
 
@@ -51,13 +53,15 @@ class DashboardService:
             dashboard_data["context"]["transport"] = {"error": str(e)}
 
         try:
-            dashboard_data["context"]["tide"] = await self.context_service.get_dashboard_tide_context()
+            dashboard_data["context"][
+                "tide"
+            ] = await self.context_service.get_dashboard_tide_context()
         except Exception as e:
             dashboard_data["context"]["tide"] = {"error": str(e)}
 
         try:
-            dashboard_data["context"]["walk_hotspots"] = await self.context_service.get_walk_hotspots(
-                days=5
+            dashboard_data["context"]["walk_hotspots"] = (
+                await self.context_service.get_walk_hotspots(days=5)
             )
         except Exception as e:
             dashboard_data["context"]["walk_hotspots"] = {"error": str(e)}
@@ -116,7 +120,9 @@ class DashboardService:
                 }
 
             hours_slept = [
-                round((sleep.total_time_in_bed_time_milli - sleep.total_awake_time_milli) / 3600000, 2)
+                round(
+                    (sleep.total_time_in_bed_time_milli - sleep.total_awake_time_milli) / 3600000, 2
+                )
                 for sleep in sleeps
                 if sleep.total_time_in_bed_time_milli is not None
                 and sleep.total_awake_time_milli is not None

--- a/whoopdata/services/health_metrics_service.py
+++ b/whoopdata/services/health_metrics_service.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Session
 from statistics import mean
 from datetime import datetime
 
-from whoopdata.models.models import Recovery, Sleep, Workout
 from whoopdata.crud.recovery import get_recoveries
 from whoopdata.crud.sleep import get_sleep
 from whoopdata.crud.workout import get_recoveries as get_workouts

--- a/whoopdata/services/insight_context_service.py
+++ b/whoopdata/services/insight_context_service.py
@@ -54,9 +54,7 @@ class InsightContextService:
 
         today_forecast = forecast.get("forecast", [])[:8]
         temps = [item["temperature"] for item in today_forecast if "temperature" in item]
-        forecast_summary = (
-            f"High {max(temps):.0f}°C, Low {min(temps):.0f}°C" if temps else None
-        )
+        forecast_summary = f"High {max(temps):.0f}°C, Low {min(temps):.0f}°C" if temps else None
 
         return {
             "current": {
@@ -172,9 +170,7 @@ class InsightContextService:
                 "max_score": 7,
                 "tide_height": round(spot["tide_height"], 2),
                 "temperature": (
-                    round(spot["temperature"], 1)
-                    if spot["temperature"] is not None
-                    else None
+                    round(spot["temperature"], 1) if spot["temperature"] is not None else None
                 ),
                 "conditions": spot["conditions"],
             }

--- a/whoopdata/services/lifecycle.py
+++ b/whoopdata/services/lifecycle.py
@@ -11,7 +11,7 @@ Phases:
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Dict
 
 import pandas as pd
 from sqlalchemy.orm import Session

--- a/whoopdata/services/personas.py
+++ b/whoopdata/services/personas.py
@@ -8,7 +8,6 @@ Defines different coaching tones and styles that can be applied to:
 
 from typing import Dict, Optional
 
-
 # Persona definitions
 PERSONAS: Dict[str, Dict] = {
     "direct_coach": {

--- a/whoopdata/services/proactive_coach.py
+++ b/whoopdata/services/proactive_coach.py
@@ -1,0 +1,566 @@
+"""Planner and dispatcher for proactive coaching nudges."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+from whoopdata.models.models import Cycle, ProactiveMessageLog, Workout, WithingsWeight
+from whoopdata.utils.sport_mapping import get_sport_name
+
+logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+class ProactiveMode:
+    MORNING = "morning"
+    WINDOW = "window"
+
+
+class ProactiveIntent:
+    MORNING_BRIEFING = "morning_briefing"
+    STRESS_CHECK_IN = "stress_hidden_load_check_in"
+    ACTIVITY_ADHERENCE = "activity_adherence_nudge"
+    MEASUREMENT_FRESHNESS = "measurement_freshness_reminder"
+    BARRIER_RESOLUTION = "barrier_resolution_coaching"
+
+
+@dataclass(frozen=True)
+class ProactiveCoachConfig:
+    enabled: bool = True
+    window_start_hour: int = 8
+    window_end_hour: int = 14
+    global_cooldown_hours: int = 4
+    duplicate_cooldown_hours: int = 24
+    morning_cooldown_hours: int = 8
+    hidden_load_strain_threshold: float = 10.0
+    run_gap_days: int = 7
+    run_history_days: int = 90
+    min_runs_for_habit_signal: int = 3
+    weight_stale_days: int = 7
+    escalation_delay_days: int = 3
+
+    @classmethod
+    def from_env(cls) -> "ProactiveCoachConfig":
+        return cls(
+            enabled=_env_bool("PROACTIVE_COACH_ENABLED", True),
+            window_start_hour=_env_int("PROACTIVE_WINDOW_START_HOUR", 8),
+            window_end_hour=_env_int("PROACTIVE_WINDOW_END_HOUR", 14),
+            global_cooldown_hours=_env_int("PROACTIVE_GLOBAL_COOLDOWN_HOURS", 4),
+            duplicate_cooldown_hours=_env_int("PROACTIVE_DUPLICATE_COOLDOWN_HOURS", 24),
+            morning_cooldown_hours=_env_int("PROACTIVE_MORNING_COOLDOWN_HOURS", 8),
+            hidden_load_strain_threshold=_env_float("PROACTIVE_HIDDEN_LOAD_STRAIN_THRESHOLD", 10.0),
+            run_gap_days=_env_int("PROACTIVE_RUN_GAP_DAYS", 7),
+            run_history_days=_env_int("PROACTIVE_RUN_HISTORY_DAYS", 90),
+            min_runs_for_habit_signal=_env_int("PROACTIVE_MIN_RUNS_FOR_HABIT_SIGNAL", 3),
+            weight_stale_days=_env_int("PROACTIVE_WEIGHT_STALE_DAYS", 7),
+            escalation_delay_days=_env_int("PROACTIVE_ESCALATION_DELAY_DAYS", 3),
+        )
+
+
+@dataclass(frozen=True)
+class ProactiveDecision:
+    should_send: bool
+    mode: str
+    intent: str | None = None
+    reason: str | None = None
+    trigger_fingerprint: str | None = None
+    evidence: dict[str, Any] = field(default_factory=dict)
+    internal_prompt: str | None = None
+
+    @classmethod
+    def skip(cls, *, mode: str, reason: str) -> "ProactiveDecision":
+        return cls(should_send=False, mode=mode, reason=reason)
+
+
+class ProactiveMessageRepository:
+    """Persistence helper for proactive message cooldowns and escalation."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def has_recent_event(self, *, chat_id: int, since: datetime) -> bool:
+        return (
+            self.db.query(ProactiveMessageLog)
+            .filter(ProactiveMessageLog.chat_id == chat_id, ProactiveMessageLog.sent_at >= since)
+            .first()
+            is not None
+        )
+
+    def latest_for_intent(self, *, chat_id: int, intent: str) -> ProactiveMessageLog | None:
+        return (
+            self.db.query(ProactiveMessageLog)
+            .filter(ProactiveMessageLog.chat_id == chat_id, ProactiveMessageLog.intent == intent)
+            .order_by(ProactiveMessageLog.sent_at.desc())
+            .first()
+        )
+
+    def latest_for_fingerprint(
+        self,
+        *,
+        chat_id: int,
+        trigger_fingerprint: str,
+    ) -> ProactiveMessageLog | None:
+        return (
+            self.db.query(ProactiveMessageLog)
+            .filter(
+                ProactiveMessageLog.chat_id == chat_id,
+                ProactiveMessageLog.trigger_fingerprint == trigger_fingerprint,
+            )
+            .order_by(ProactiveMessageLog.sent_at.desc())
+            .first()
+        )
+
+    def record_sent(
+        self,
+        *,
+        chat_id: int,
+        decision: ProactiveDecision,
+        telegram_message_id: int | None = None,
+        sent_at: datetime | None = None,
+    ) -> ProactiveMessageLog:
+        record = ProactiveMessageLog(
+            chat_id=chat_id,
+            mode=decision.mode,
+            intent=decision.intent or "unknown",
+            trigger_fingerprint=decision.trigger_fingerprint,
+            reason=decision.reason,
+            evidence_json=json.dumps(decision.evidence, sort_keys=True, default=str),
+            prompt=decision.internal_prompt or "",
+            telegram_message_id=telegram_message_id,
+            sent_at=sent_at or datetime.utcnow(),
+        )
+        self.db.add(record)
+        self.db.commit()
+        self.db.refresh(record)
+        return record
+
+
+class ProactiveCoachPlanner:
+    """Deterministic planner for proactive coaching nudges."""
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        config: ProactiveCoachConfig | None = None,
+        now_fn: Callable[[], datetime] | None = None,
+        repository: ProactiveMessageRepository | None = None,
+    ) -> None:
+        self.db = db
+        self.config = config or ProactiveCoachConfig.from_env()
+        self.now_fn = now_fn or datetime.utcnow
+        self.repository = repository or ProactiveMessageRepository(db)
+
+    def evaluate(self, *, mode: str, chat_id: int) -> ProactiveDecision:
+        now = self.now_fn()
+
+        if not self.config.enabled:
+            return ProactiveDecision.skip(mode=mode, reason="Proactive coaching is disabled")
+
+        if mode == ProactiveMode.WINDOW and not self._within_window(now):
+            return ProactiveDecision.skip(mode=mode, reason="Outside configured proactive window")
+
+        if self.repository.has_recent_event(
+            chat_id=chat_id,
+            since=now - timedelta(hours=self.config.global_cooldown_hours),
+        ):
+            return ProactiveDecision.skip(mode=mode, reason="Recent proactive message still cooling down")
+
+        for builder in (
+            self._build_hidden_load_decision,
+            self._build_run_gap_decision,
+            self._build_weight_stale_decision,
+        ):
+            decision = builder(chat_id=chat_id, now=now, mode=mode)
+            if decision is not None:
+                return decision
+
+        if mode == ProactiveMode.MORNING:
+            latest_morning = self.repository.latest_for_intent(
+                chat_id=chat_id,
+                intent=ProactiveIntent.MORNING_BRIEFING,
+            )
+            if latest_morning and latest_morning.sent_at >= now - timedelta(
+                hours=self.config.morning_cooldown_hours
+            ):
+                return ProactiveDecision.skip(
+                    mode=mode,
+                    reason="Recent morning briefing still cooling down",
+                )
+            return self._build_morning_briefing(now=now, mode=mode)
+
+        return ProactiveDecision.skip(mode=mode, reason="No proactive trigger fired")
+
+    def record_sent(
+        self,
+        *,
+        chat_id: int,
+        decision: ProactiveDecision,
+        telegram_message_id: int | None = None,
+        sent_at: datetime | None = None,
+    ) -> ProactiveMessageLog:
+        return self.repository.record_sent(
+            chat_id=chat_id,
+            decision=decision,
+            telegram_message_id=telegram_message_id,
+            sent_at=sent_at,
+        )
+
+    @staticmethod
+    def default_chat_id() -> int | None:
+        raw = os.getenv("TELEGRAM_ALLOWED_CHAT_IDS", "").split(",")[0].strip()
+        if not raw:
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+
+    def _within_window(self, now: datetime) -> bool:
+        return self.config.window_start_hour <= now.hour <= self.config.window_end_hour
+
+    def _build_morning_briefing(self, *, now: datetime, mode: str) -> ProactiveDecision:
+        evidence = {
+            "generated_at": now.isoformat(),
+            "mode": mode,
+        }
+        return ProactiveDecision(
+            should_send=True,
+            mode=mode,
+            intent=ProactiveIntent.MORNING_BRIEFING,
+            reason="Scheduled morning briefing",
+            trigger_fingerprint=f"morning:{now.date().isoformat()}",
+            evidence=evidence,
+            internal_prompt=self._build_internal_prompt(
+                intent=ProactiveIntent.MORNING_BRIEFING,
+                evidence=evidence,
+                ux_contract=(
+                    "Start with a short state summary based on the latest WHOOP and Withings data.",
+                    "Give exactly one priority for today.",
+                    "Optionally ask one short follow-up question.",
+                    "Keep the message concise and grounded in the latest data.",
+                ),
+            ),
+        )
+
+    def _build_hidden_load_decision(
+        self,
+        *,
+        chat_id: int,
+        now: datetime,
+        mode: str,
+    ) -> ProactiveDecision | None:
+        latest_cycle = self.db.query(Cycle).order_by(Cycle.start.desc(), Cycle.created_at.desc()).first()
+        if latest_cycle is None or latest_cycle.strain is None:
+            return None
+        if latest_cycle.strain <= self.config.hidden_load_strain_threshold:
+            return None
+
+        workouts = (
+            self.db.query(Workout)
+            .filter(Workout.cycle_id == latest_cycle.id)
+            .order_by(Workout.start.desc(), Workout.created_at.desc())
+            .all()
+        )
+        workout_sports = [get_sport_name(workout.sport_id) for workout in workouts]
+        if workouts and not all(workout.sport_id == 63 for workout in workouts):
+            return None
+
+        cycle_anchor = latest_cycle.start or latest_cycle.created_at or now
+        fingerprint = f"hidden-load:{cycle_anchor.date().isoformat()}"
+        latest_event = self.repository.latest_for_fingerprint(
+            chat_id=chat_id,
+            trigger_fingerprint=fingerprint,
+        )
+        if latest_event and latest_event.sent_at >= now - timedelta(
+            hours=self.config.duplicate_cooldown_hours
+        ):
+            return None
+
+        reason = (
+            "High daily strain with only walking workouts suggests hidden load or stress"
+            if workouts
+            else "High daily strain without a matching workout suggests hidden load or stress"
+        )
+        evidence = {
+            "cycle_date": cycle_anchor.date().isoformat(),
+            "cycle_strain": round(float(latest_cycle.strain), 2),
+            "workout_count_for_cycle": len(workouts),
+            "workout_sports": workout_sports,
+        }
+        return ProactiveDecision(
+            should_send=True,
+            mode=mode,
+            intent=ProactiveIntent.STRESS_CHECK_IN,
+            reason=reason,
+            trigger_fingerprint=fingerprint,
+            evidence=evidence,
+            internal_prompt=self._build_internal_prompt(
+                intent=ProactiveIntent.STRESS_CHECK_IN,
+                evidence=evidence,
+                ux_contract=(
+                    "Explicitly name the mismatch in the data.",
+                    "Validate that non-exercise stress or hidden load may explain it.",
+                    "Ask one short check-in question.",
+                    "Offer one or two low-friction recovery options.",
+                    "Keep it concise and avoid sounding alarmist.",
+                ),
+            ),
+        )
+
+    def _build_run_gap_decision(
+        self,
+        *,
+        chat_id: int,
+        now: datetime,
+        mode: str,
+    ) -> ProactiveDecision | None:
+        history_cutoff = now - timedelta(days=self.config.run_history_days)
+        run_history_count = (
+            self.db.query(Workout)
+            .filter(
+                Workout.sport_id == 0,
+                Workout.start.isnot(None),
+                Workout.start >= history_cutoff,
+            )
+            .count()
+        )
+        if run_history_count < self.config.min_runs_for_habit_signal:
+            return None
+
+        last_run = (
+            self.db.query(Workout)
+            .filter(Workout.sport_id == 0, Workout.start.isnot(None))
+            .order_by(Workout.start.desc())
+            .first()
+        )
+        if last_run is None or last_run.start is None:
+            return None
+
+        days_since_last_run = (now.date() - last_run.start.date()).days
+        if days_since_last_run < self.config.run_gap_days:
+            return None
+
+        fingerprint = f"run-gap:{last_run.start.date().isoformat()}"
+        latest_event = self.repository.latest_for_fingerprint(
+            chat_id=chat_id,
+            trigger_fingerprint=fingerprint,
+        )
+        if latest_event and latest_event.sent_at >= now - timedelta(
+            hours=self.config.duplicate_cooldown_hours
+        ):
+            return None
+
+        escalating = bool(
+            latest_event and latest_event.sent_at <= now - timedelta(days=self.config.escalation_delay_days)
+        )
+        intent = (
+            ProactiveIntent.BARRIER_RESOLUTION
+            if escalating
+            else ProactiveIntent.ACTIVITY_ADHERENCE
+        )
+        reason = (
+            "Running gap persists after an earlier reminder"
+            if escalating
+            else "Running habit appears to have gone quiet"
+        )
+        evidence = {
+            "days_since_last_run": days_since_last_run,
+            "last_run_at": last_run.start.isoformat(),
+            "run_history_days": self.config.run_history_days,
+            "recent_run_history_count": run_history_count,
+            "target_behaviour": "running",
+        }
+        return ProactiveDecision(
+            should_send=True,
+            mode=mode,
+            intent=intent,
+            reason=reason,
+            trigger_fingerprint=fingerprint,
+            evidence=evidence,
+            internal_prompt=self._build_internal_prompt(
+                intent=intent,
+                evidence=evidence,
+                ux_contract=self._ux_contract_for_running(intent=intent),
+            ),
+        )
+
+    def _build_weight_stale_decision(
+        self,
+        *,
+        chat_id: int,
+        now: datetime,
+        mode: str,
+    ) -> ProactiveDecision | None:
+        latest_weight = (
+            self.db.query(WithingsWeight)
+            .filter(WithingsWeight.weight_kg.isnot(None), WithingsWeight.datetime.isnot(None))
+            .order_by(WithingsWeight.datetime.desc())
+            .first()
+        )
+        if latest_weight is None or latest_weight.datetime is None:
+            return None
+
+        days_since_weight = (now.date() - latest_weight.datetime.date()).days
+        if days_since_weight < self.config.weight_stale_days:
+            return None
+
+        fingerprint = f"weight-stale:{latest_weight.datetime.date().isoformat()}"
+        latest_event = self.repository.latest_for_fingerprint(
+            chat_id=chat_id,
+            trigger_fingerprint=fingerprint,
+        )
+        if latest_event and latest_event.sent_at >= now - timedelta(
+            hours=self.config.duplicate_cooldown_hours
+        ):
+            return None
+
+        escalating = bool(
+            latest_event and latest_event.sent_at <= now - timedelta(days=self.config.escalation_delay_days)
+        )
+        intent = (
+            ProactiveIntent.BARRIER_RESOLUTION
+            if escalating
+            else ProactiveIntent.MEASUREMENT_FRESHNESS
+        )
+        reason = (
+            "Weight-measurement gap persists after an earlier reminder"
+            if escalating
+            else "Withings weight data has gone stale"
+        )
+        evidence = {
+            "days_since_last_weight_measurement": days_since_weight,
+            "last_weight_at": latest_weight.datetime.isoformat(),
+            "target_behaviour": "capture a fresh Withings weight measurement",
+        }
+        return ProactiveDecision(
+            should_send=True,
+            mode=mode,
+            intent=intent,
+            reason=reason,
+            trigger_fingerprint=fingerprint,
+            evidence=evidence,
+            internal_prompt=self._build_internal_prompt(
+                intent=intent,
+                evidence=evidence,
+                ux_contract=self._ux_contract_for_weight(intent=intent),
+            ),
+        )
+
+    @staticmethod
+    def _ux_contract_for_running(*, intent: str) -> tuple[str, ...]:
+        if intent == ProactiveIntent.BARRIER_RESOLUTION:
+            return (
+                "Acknowledge that the same running gap is still unresolved.",
+                "Use the behaviour_change specialist for a COM-B informed response before replying.",
+                "Frame the likely blocker, then give one micro-action, two or three options, one barrier-buster, and one follow-up question.",
+                "Do not repeat the earlier reminder verbatim.",
+            )
+        return (
+            "Remind the user of the running habit or goal without sounding punitive.",
+            "State the gap plainly and suggest one tiny next step or a reschedule option.",
+            "Ask at most one short follow-up question.",
+            "Keep the message concise and action-oriented.",
+        )
+
+    @staticmethod
+    def _ux_contract_for_weight(*, intent: str) -> tuple[str, ...]:
+        if intent == ProactiveIntent.BARRIER_RESOLUTION:
+            return (
+                "Treat this as a recurring measurement gap, not a one-off reminder.",
+                "Use the behaviour_change specialist for a COM-B informed response before replying.",
+                "Frame the likely blocker, then give one micro-action, two or three options, one barrier-buster, and one follow-up question.",
+                "Keep the tone practical and low-friction.",
+            )
+        return (
+            "Explain briefly why a fresh weight measurement would help.",
+            "Suggest the easiest moment to do it today.",
+            "Ask for only one simple action.",
+            "Keep the message concise and practical.",
+        )
+
+    @staticmethod
+    def _build_internal_prompt(
+        *,
+        intent: str,
+        evidence: dict[str, Any],
+        ux_contract: tuple[str, ...],
+    ) -> str:
+        lines = [
+            "You are sending a proactive Telegram coaching message.",
+            "The user did not type a new message; you are initiating the conversation.",
+            f"Intent: {intent}",
+            "Ground the reply in the evidence below.",
+            "Write for Telegram as plain chat text, not an email, memo, or report.",
+            "Do not use markdown headings, markdown tables, or multi-section templates.",
+            "Use at most 4 short lines and keep the final message under 450 characters.",
+            "Keep the message concise, personalised, evidence-linked, and limited to one primary action request.",
+            "Ask at most one follow-up question.",
+            "If relevant, search memory or use the appropriate specialist before drafting the final reply.",
+        ]
+        if intent == ProactiveIntent.BARRIER_RESOLUTION:
+            lines.append(
+                "IMPORTANT: Use the behaviour_change specialist so the reply is COM-B informed and helps the user overcome likely blockers."
+            )
+        lines.append("UX contract:")
+        lines.extend(f"- {rule}" for rule in ux_contract)
+        lines.append("Evidence:")
+        lines.append(json.dumps(evidence, indent=2, sort_keys=True, default=str))
+        return "\n".join(lines)
+
+
+async def dispatch_proactive_message(
+    *,
+    planner: ProactiveCoachPlanner,
+    chat_id: int,
+    mode: str,
+    push_fn: Callable[..., Any],
+) -> tuple[ProactiveDecision, Any | None]:
+    """Evaluate a proactive decision, send it if needed, and record the send."""
+    decision = planner.evaluate(mode=mode, chat_id=chat_id)
+    if not decision.should_send or not decision.internal_prompt:
+        return decision, None
+
+    result = await push_fn(
+        chat_id=chat_id,
+        prompt=decision.internal_prompt,
+    )
+    planner.record_sent(
+        chat_id=chat_id,
+        decision=decision,
+        telegram_message_id=result.telegram_message_id,
+    )
+    return decision, result

--- a/whoopdata/services/proactive_coach.py
+++ b/whoopdata/services/proactive_coach.py
@@ -197,7 +197,9 @@ class ProactiveCoachPlanner:
             chat_id=chat_id,
             since=now - timedelta(hours=self.config.global_cooldown_hours),
         ):
-            return ProactiveDecision.skip(mode=mode, reason="Recent proactive message still cooling down")
+            return ProactiveDecision.skip(
+                mode=mode, reason="Recent proactive message still cooling down"
+            )
 
         for builder in (
             self._build_hidden_load_decision,
@@ -257,6 +259,24 @@ class ProactiveCoachPlanner:
             "generated_at": now.isoformat(),
             "mode": mode,
         }
+
+        # Add persisted actionability thresholds when available so the message can
+        # say "keep strain under X and bedtime before Y".
+        try:
+            from whoopdata.analytics.results_loader import results_loader
+
+            actionability = results_loader.load_result("recovery_actionability", days_back=365)
+            if actionability and isinstance(actionability, dict):
+                best = actionability.get("best_thresholds") or {}
+                strain_max = best.get("strain_3d_sum_max")
+                bedtime_before = best.get("bedtime_before")
+                if strain_max is not None or bedtime_before:
+                    evidence["recovery_actionability"] = {
+                        "strain_3d_sum_max": strain_max,
+                        "bedtime_before": bedtime_before,
+                    }
+        except Exception:
+            pass
         return ProactiveDecision(
             should_send=True,
             mode=mode,
@@ -283,7 +303,9 @@ class ProactiveCoachPlanner:
         now: datetime,
         mode: str,
     ) -> ProactiveDecision | None:
-        latest_cycle = self.db.query(Cycle).order_by(Cycle.start.desc(), Cycle.created_at.desc()).first()
+        latest_cycle = (
+            self.db.query(Cycle).order_by(Cycle.start.desc(), Cycle.created_at.desc()).first()
+        )
         if latest_cycle is None or latest_cycle.strain is None:
             return None
         if latest_cycle.strain <= self.config.hidden_load_strain_threshold:
@@ -385,12 +407,11 @@ class ProactiveCoachPlanner:
             return None
 
         escalating = bool(
-            latest_event and latest_event.sent_at <= now - timedelta(days=self.config.escalation_delay_days)
+            latest_event
+            and latest_event.sent_at <= now - timedelta(days=self.config.escalation_delay_days)
         )
         intent = (
-            ProactiveIntent.BARRIER_RESOLUTION
-            if escalating
-            else ProactiveIntent.ACTIVITY_ADHERENCE
+            ProactiveIntent.BARRIER_RESOLUTION if escalating else ProactiveIntent.ACTIVITY_ADHERENCE
         )
         reason = (
             "Running gap persists after an earlier reminder"
@@ -449,7 +470,8 @@ class ProactiveCoachPlanner:
             return None
 
         escalating = bool(
-            latest_event and latest_event.sent_at <= now - timedelta(days=self.config.escalation_delay_days)
+            latest_event
+            and latest_event.sent_at <= now - timedelta(days=self.config.escalation_delay_days)
         )
         intent = (
             ProactiveIntent.BARRIER_RESOLUTION

--- a/whoopdata/services/scenario_planner.py
+++ b/whoopdata/services/scenario_planner.py
@@ -8,7 +8,7 @@ Wraps the existing RecoveryPredictor with user-friendly framing:
 
 import logging
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List
 from statistics import mean
 
 from sqlalchemy.orm import Session

--- a/whoopdata/services/tide_service.py
+++ b/whoopdata/services/tide_service.py
@@ -1,4 +1,5 @@
 """Thames Tide Service for Environment Agency API."""
+
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -12,20 +13,20 @@ class TideService:
     """Service for fetching Thames tide data from Environment Agency."""
 
     BASE_URL = "https://environment.data.gov.uk/flood-monitoring"
-    
+
     # East London tidal stations
     STATIONS = {
         "silvertown": "0001",
         "charlton": "0003",
         "tower_pier": "0007",
     }
-    
+
     # Default station for queries
     DEFAULT_STATION = "silvertown"
 
     def __init__(self, timeout: int = 10):
         """Initialize tide service.
-        
+
         Args:
             timeout: Request timeout in seconds
         """
@@ -33,10 +34,10 @@ class TideService:
 
     async def get_station_data(self, station_id: str) -> Optional[TideStation]:
         """Get metadata for a tidal station.
-        
+
         Args:
             station_id: Station ID (e.g. "0001" for Silvertown)
-            
+
         Returns:
             TideStation object or None if request fails
         """
@@ -45,7 +46,7 @@ class TideService:
                 response = await client.get(f"{self.BASE_URL}/id/stations/{station_id}")
                 response.raise_for_status()
                 data = response.json()
-                
+
                 items = data.get("items", {})
                 return TideStation(
                     station_id=items.get("notation"),
@@ -59,10 +60,10 @@ class TideService:
 
     async def get_latest_reading(self, station_id: str) -> Optional[TideReading]:
         """Get the latest tide reading for a station.
-        
+
         Args:
             station_id: Station ID (e.g. "0001" for Silvertown)
-            
+
         Returns:
             TideReading object or None if request fails
         """
@@ -73,17 +74,15 @@ class TideService:
                 )
                 response.raise_for_status()
                 data = response.json()
-                
+
                 items = data.get("items", [])
                 if not items:
                     return None
-                    
+
                 reading = items[0]
                 return TideReading(
                     station_id=station_id,
-                    timestamp=datetime.fromisoformat(
-                        reading["dateTime"].replace("Z", "+00:00")
-                    ),
+                    timestamp=datetime.fromisoformat(reading["dateTime"].replace("Z", "+00:00")),
                     value=reading["value"],
                     unit="mAOD",
                 )
@@ -91,62 +90,60 @@ class TideService:
             logger.error(f"Failed to get latest reading for {station_id}: {e}")
             return None
 
-    async def get_readings_range(
-        self, 
-        station_id: str, 
-        hours: int = 24
-    ) -> list[TideReading]:
+    async def get_readings_range(self, station_id: str, hours: int = 24) -> list[TideReading]:
         """Get tide readings for the past N hours.
-        
+
         Args:
             station_id: Station ID
             hours: Number of hours to look back
-            
+
         Returns:
             List of TideReading objects
         """
         try:
             # 15-min intervals = 4 readings per hour
             limit = hours * 4
-            
+
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(
                     f"{self.BASE_URL}/id/stations/{station_id}/readings",
-                    params={"_sorted": "true", "_limit": limit}
+                    params={"_sorted": "true", "_limit": limit},
                 )
                 response.raise_for_status()
                 data = response.json()
-                
+
                 readings = []
                 for item in data.get("items", []):
-                    readings.append(TideReading(
-                        station_id=station_id,
-                        timestamp=datetime.fromisoformat(
-                            item["dateTime"].replace("Z", "+00:00")
-                        ),
-                        value=item["value"],
-                        unit="mAOD",
-                    ))
-                
+                    readings.append(
+                        TideReading(
+                            station_id=station_id,
+                            timestamp=datetime.fromisoformat(
+                                item["dateTime"].replace("Z", "+00:00")
+                            ),
+                            value=item["value"],
+                            unit="mAOD",
+                        )
+                    )
+
                 # Sort by timestamp ascending
                 readings.sort(key=lambda r: r.timestamp)
                 return readings
-                
+
         except Exception as e:
             logger.error(f"Failed to get readings range for {station_id}: {e}")
             return []
 
     async def calculate_tidal_range(self, station_id: str) -> dict:
         """Calculate tidal range statistics for the past 24 hours.
-        
+
         Args:
             station_id: Station ID
-            
+
         Returns:
             Dict with min, max, range, and mean values
         """
         readings = await self.get_readings_range(station_id, hours=24)
-        
+
         if not readings:
             return {
                 "min": None,
@@ -154,11 +151,11 @@ class TideService:
                 "range": None,
                 "mean": None,
             }
-        
+
         values = [r.value for r in readings]
         min_val = min(values)
         max_val = max(values)
-        
+
         return {
             "min": round(min_val, 3),
             "max": round(max_val, 3),
@@ -166,26 +163,22 @@ class TideService:
             "mean": round(sum(values) / len(values), 3),
         }
 
-    async def get_tide_forecast(
-        self, 
-        station_id: str, 
-        hours_ahead: int = 24
-    ) -> TideForecast:
+    async def get_tide_forecast(self, station_id: str, hours_ahead: int = 24) -> TideForecast:
         """Generate tide forecast using tidal prediction.
-        
+
         Uses simple harmonic analysis of past 24h data to predict
         high/low tides for the next N hours.
-        
+
         Args:
             station_id: Station ID
             hours_ahead: Hours to forecast ahead (default 24)
-            
+
         Returns:
             TideForecast object with predicted high/low tides
         """
         # Get past 24h of readings for pattern analysis
         readings = await self.get_readings_range(station_id, hours=24)
-        
+
         if len(readings) < 48:  # Need at least 12 hours of data
             logger.warning(f"Insufficient data for forecast ({len(readings)} readings)")
             return TideForecast(
@@ -195,69 +188,77 @@ class TideService:
                 high_tides=[],
                 low_tides=[],
             )
-        
+
         # Find turning points (high/low tides)
         high_tides = []
         low_tides = []
-        
+
         for i in range(1, len(readings) - 1):
             prev_val = readings[i - 1].value
             curr_val = readings[i].value
             next_val = readings[i + 1].value
-            
+
             # High tide: local maximum
             if curr_val > prev_val and curr_val > next_val:
-                high_tides.append({
-                    "time": readings[i].timestamp,
-                    "height": curr_val,
-                })
-            
+                high_tides.append(
+                    {
+                        "time": readings[i].timestamp,
+                        "height": curr_val,
+                    }
+                )
+
             # Low tide: local minimum
             elif curr_val < prev_val and curr_val < next_val:
-                low_tides.append({
-                    "time": readings[i].timestamp,
-                    "height": curr_val,
-                })
-        
+                low_tides.append(
+                    {
+                        "time": readings[i].timestamp,
+                        "height": curr_val,
+                    }
+                )
+
         # Calculate average period between tides (Thames is semi-diurnal: ~12.4h)
         if len(high_tides) >= 2:
             high_periods = [
-                (high_tides[i]["time"] - high_tides[i-1]["time"]).total_seconds() / 3600
+                (high_tides[i]["time"] - high_tides[i - 1]["time"]).total_seconds() / 3600
                 for i in range(1, len(high_tides))
             ]
             avg_period = sum(high_periods) / len(high_periods)
         else:
             avg_period = 12.4  # Thames typical semi-diurnal period
-        
+
         # Extrapolate next tides
         predicted_high = []
         predicted_low = []
-        
+
         now = datetime.now(timezone.utc)
         forecast_end = now + timedelta(hours=hours_ahead)
-        
+
         if high_tides:
             last_high = high_tides[-1]
             next_high_time = last_high["time"] + timedelta(hours=avg_period)
-            
+
             while next_high_time < forecast_end:
-                predicted_high.append({
-                    "time": next_high_time,
-                    "height": last_high["height"],  # Use last observed height
-                })
+                predicted_high.append(
+                    {
+                        "time": next_high_time,
+                        "height": last_high["height"],  # Use last observed height
+                    }
+                )
                 next_high_time += timedelta(hours=avg_period)
-        
+
         if low_tides:
             last_low = low_tides[-1]
             next_low_time = last_low["time"] + timedelta(hours=avg_period)
-            
+
             while next_low_time < forecast_end:
-                predicted_low.append({
-                    "time": next_low_time,
-                    "height": last_low["height"],
-                })
+                predicted_low.append(
+                    {
+                        "time": next_low_time,
+                        "height": last_low["height"],
+                    }
+                )
                 next_low_time += timedelta(hours=avg_period)
-        
+
         return TideForecast(
             station_id=station_id,
             forecast_start=now,
@@ -275,88 +276,98 @@ class TideService:
         max_hour: int = 21,
     ) -> list[dict]:
         """Calculate perfect walk time hotspots.
-        
+
         Scores times based on:
         - High tide during daylight hours (+3 points)
         - Clear skies <30% clouds (+2 points)
         - Low wind <10 mph (+1 point)
         - Comfortable temp 10-20°C (+1 point)
         - Additional points for sunset/sunrise timing
-        
+
         Only considers times between min_hour and max_hour (default 7am-9pm).
-        
+
         Args:
             weather_data: Weather forecast data with hourly conditions
             station_id: Station ID (defaults to Silvertown)
             days_ahead: Number of days to analyze (default 3)
             min_hour: Earliest hour to consider (default 7 for 7am)
             max_hour: Latest hour to consider (default 21 for 9pm)
-            
+
         Returns:
             List of hotspot dicts with time, score, temperature, and conditions
         """
         if station_id is None:
             station_id = self.STATIONS[self.DEFAULT_STATION]
-        
+
         # Get tide forecast
         forecast = await self.get_tide_forecast(station_id, hours_ahead=days_ahead * 24)
-        
+
         # Get sunrise/sunset times from weather data
         sunrise_timestamp = weather_data.get("sunrise")
         sunset_timestamp = weather_data.get("sunset")
-        
+
         hotspots = []
-        
+
         # Check each high tide
         for high_tide in forecast.high_tides:
             tide_time = high_tide["time"]
-            
+
             # Skip if outside practical hours (default: before 7am or after 9pm)
             local_hour = tide_time.hour  # Assuming UTC, adjust if needed
             if local_hour < min_hour or local_hour > max_hour:
                 continue
-            
+
             score = 0
             conditions = []
             temp_c = None
-            
+
             # Base points for being during daylight/practical hours
             if sunrise_timestamp and sunset_timestamp:
                 sunrise_dt = datetime.fromtimestamp(sunrise_timestamp, tz=timezone.utc)
                 sunset_dt = datetime.fromtimestamp(sunset_timestamp, tz=timezone.utc)
                 tide_date = tide_time.date()
-                sunrise_on_tide_date = datetime.combine(tide_date, sunrise_dt.time(), tzinfo=timezone.utc)
-                sunset_on_tide_date = datetime.combine(tide_date, sunset_dt.time(), tzinfo=timezone.utc)
-                
+                sunrise_on_tide_date = datetime.combine(
+                    tide_date, sunrise_dt.time(), tzinfo=timezone.utc
+                )
+                sunset_on_tide_date = datetime.combine(
+                    tide_date, sunset_dt.time(), tzinfo=timezone.utc
+                )
+
                 # Check if during daylight hours
                 if sunrise_on_tide_date <= tide_time <= sunset_on_tide_date:
                     score += 2
                     conditions.append("Daylight hours")
-            
+
             # Bonus points for being near sunset or sunrise (within 1 hour)
             is_sunset_time = False
             is_sunrise_time = False
-            
+
             if sunset_timestamp:
                 sunset_dt = datetime.fromtimestamp(sunset_timestamp, tz=timezone.utc)
                 tide_date = tide_time.date()
-                sunset_on_tide_date = datetime.combine(tide_date, sunset_dt.time(), tzinfo=timezone.utc)
+                sunset_on_tide_date = datetime.combine(
+                    tide_date, sunset_dt.time(), tzinfo=timezone.utc
+                )
                 time_diff = abs((tide_time - sunset_on_tide_date).total_seconds() / 3600)
                 if time_diff <= 1:  # Within 1 hour of sunset
                     score += 2
                     conditions.append("Near sunset")
                     is_sunset_time = True
-            
+
             if not is_sunset_time and sunrise_timestamp:
                 sunrise_dt = datetime.fromtimestamp(sunrise_timestamp, tz=timezone.utc)
                 tide_date = tide_time.date()
-                sunrise_on_tide_date = datetime.combine(tide_date, sunrise_dt.time(), tzinfo=timezone.utc)
+                sunrise_on_tide_date = datetime.combine(
+                    tide_date, sunrise_dt.time(), tzinfo=timezone.utc
+                )
                 time_diff = abs((tide_time - sunrise_on_tide_date).total_seconds() / 3600)
-                if time_diff <= 1 and local_hour >= min_hour:  # Within 1 hour of sunrise AND after min_hour
+                if (
+                    time_diff <= 1 and local_hour >= min_hour
+                ):  # Within 1 hour of sunrise AND after min_hour
                     score += 2
                     conditions.append("Near sunrise")
                     is_sunrise_time = True
-            
+
             # Find matching weather data for this time
             # Assumes weather_data has 'hourly' list with 'dt' timestamps
             if "hourly" in weather_data:
@@ -366,41 +377,43 @@ class TideService:
                     if abs((hour_dt - tide_time).total_seconds()) < 3600:  # Within 1 hour
                         matching_weather = hour_data
                         break
-                
+
                 if matching_weather:
                     # Check cloud cover
                     clouds = matching_weather.get("clouds", 100)
                     if clouds < 30:
                         score += 2
                         conditions.append(f"Clear skies ({clouds}% clouds)")
-                    
+
                     # Check wind speed (convert m/s to mph: 1 m/s ≈ 2.237 mph)
                     wind_ms = matching_weather.get("wind_speed", 0)
                     wind_mph = wind_ms * 2.237
                     if wind_mph < 10:
                         score += 1
                         conditions.append(f"Low wind ({wind_mph:.1f} mph)")
-                    
+
                     # Check temperature
                     temp_k = matching_weather.get("temp", 273)
                     temp_c = temp_k - 273.15
                     if 10 <= temp_c <= 20:
                         score += 1
                         conditions.append(f"Comfortable temp ({temp_c:.1f}°C)")
-            
-            hotspots.append({
-                "time": tide_time,
-                "score": score,
-                "tide_height": high_tide["height"],
-                "temperature": temp_c,
-                "conditions": conditions,
-            })
-        
+
+            hotspots.append(
+                {
+                    "time": tide_time,
+                    "score": score,
+                    "tide_height": high_tide["height"],
+                    "temperature": temp_c,
+                    "conditions": conditions,
+                }
+            )
+
         # Sort by score (best first), then by time
         hotspots.sort(key=lambda x: (-x["score"], x["time"]))
-        
+
         # Update max_score to reflect new scoring (2 base + 2 sunset/sunrise + 2 clouds + 1 wind + 1 temp = 8)
         for hotspot in hotspots:
             hotspot["max_score"] = 8
-        
+
         return hotspots

--- a/whoopdata/services/weakness_reminder.py
+++ b/whoopdata/services/weakness_reminder.py
@@ -55,12 +55,8 @@ class WeaknessReminderConfig:
     def from_env(cls) -> "WeaknessReminderConfig":
         return cls(
             enabled=_env_bool("WEAKNESS_REMINDER_ENABLED", True),
-            window_start_hour=_env_int(
-                "WEAKNESS_REMINDER_WINDOW_START_HOUR", 9
-            ),
-            window_end_hour=_env_int(
-                "WEAKNESS_REMINDER_WINDOW_END_HOUR", 15
-            ),
+            window_start_hour=_env_int("WEAKNESS_REMINDER_WINDOW_START_HOUR", 9),
+            window_end_hour=_env_int("WEAKNESS_REMINDER_WINDOW_END_HOUR", 15),
         )
 
 
@@ -72,10 +68,7 @@ class WeaknessPreview:
 
 
 def default_weakness_file() -> Path:
-    raw = (
-        os.getenv("WEAKNESS_REMINDER_FILE", "weakness.md").strip()
-        or "weakness.md"
-    )
+    raw = os.getenv("WEAKNESS_REMINDER_FILE", "weakness.md").strip() or "weakness.md"
     path = Path(raw)
     if path.is_absolute():
         return path
@@ -148,10 +141,7 @@ def _build_prompt(*, point: str) -> str:
     lines = [
         f"You are {coach_name}.",
         "Send a proactive Telegram coaching message.",
-        (
-            "The user did not type a new message; "
-            "you are initiating the conversation."
-        ),
+        ("The user did not type a new message; " "you are initiating the conversation."),
         (
             "This reminder comes from the user's annual review "
             "and should keep one growth point salient."
@@ -166,9 +156,7 @@ def _build_prompt(*, point: str) -> str:
             "Telegram supports basic formatting. You may use a short header, "
             "bold, italics, and bullet points, plus an occasional emoji."
         ),
-        (
-            "Keep it concise: at most 6 short lines and under 700 characters."
-        ),
+        ("Keep it concise: at most 6 short lines and under 700 characters."),
         (
             "Focus on one point, one reflection, and at most one small action "
             "or one short question."
@@ -194,9 +182,7 @@ def build_preview(
         index = _select_index_for_day(points, day=current_day)
     else:
         if point_number < 1 or point_number > len(points):
-            raise ValueError(
-                f"point_number must be between 1 and {len(points)}"
-            )
+            raise ValueError(f"point_number must be between 1 and {len(points)}")
         index = point_number - 1
 
     point = points[index]
@@ -221,9 +207,7 @@ class WeaknessReminderPlanner:
     ) -> None:
         self.db = db
         self.weakness_file = (
-            Path(weakness_file)
-            if weakness_file is not None
-            else default_weakness_file()
+            Path(weakness_file) if weakness_file is not None else default_weakness_file()
         )
         self.config = config or WeaknessReminderConfig.from_env()
         self.now_fn = now_fn or datetime.utcnow
@@ -241,9 +225,7 @@ class WeaknessReminderPlanner:
         if now.weekday() >= 5:
             return ProactiveDecision.skip(
                 mode=WeaknessReminderMode.SCHEDULED,
-                reason=(
-                    "Weekend — weakness reminder only runs Monday to Friday"
-                ),
+                reason=("Weekend — weakness reminder only runs Monday to Friday"),
             )
 
         if not self._within_window(now):
@@ -319,11 +301,7 @@ class WeaknessReminderPlanner:
         )
 
     def _within_window(self, now: datetime) -> bool:
-        return (
-            self.config.window_start_hour
-            <= now.hour
-            <= self.config.window_end_hour
-        )
+        return self.config.window_start_hour <= now.hour <= self.config.window_end_hour
 
 
 async def dispatch_weakness_reminder(

--- a/whoopdata/services/weakness_reminder.py
+++ b/whoopdata/services/weakness_reminder.py
@@ -1,0 +1,349 @@
+"""Planner and preview helpers for weakness reminder nudges."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+from whoopdata.services.proactive_coach import (
+    ProactiveDecision,
+    ProactiveMessageRepository,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+class WeaknessReminderMode:
+    SCHEDULED = "weakness_scheduled"
+
+
+class WeaknessReminderIntent:
+    WEAKNESS_REFLECTION = "weakness_reflection_nudge"
+
+
+@dataclass(frozen=True)
+class WeaknessReminderConfig:
+    enabled: bool = True
+    window_start_hour: int = 9
+    window_end_hour: int = 15
+
+    @classmethod
+    def from_env(cls) -> "WeaknessReminderConfig":
+        return cls(
+            enabled=_env_bool("WEAKNESS_REMINDER_ENABLED", True),
+            window_start_hour=_env_int(
+                "WEAKNESS_REMINDER_WINDOW_START_HOUR", 9
+            ),
+            window_end_hour=_env_int(
+                "WEAKNESS_REMINDER_WINDOW_END_HOUR", 15
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class WeaknessPreview:
+    point: str
+    point_number: int
+    prompt: str
+
+
+def default_weakness_file() -> Path:
+    raw = (
+        os.getenv("WEAKNESS_REMINDER_FILE", "weakness.md").strip()
+        or "weakness.md"
+    )
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    return PROJECT_ROOT / path
+
+
+def parse_weakness_points(path: str | Path) -> list[str]:
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    points: list[str] = []
+    current_parts: list[str] = []
+
+    def _flush() -> None:
+        if current_parts:
+            points.append(" ".join(current_parts).strip())
+            current_parts.clear()
+
+    for line in lines:
+        if line.startswith("- ") or line.startswith("* "):
+            _flush()
+            current_parts.append(line[2:].strip())
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            _flush()
+            continue
+
+        if line.startswith((" ", "\t")):
+            if current_parts and not stripped.startswith(("- ", "* ")):
+                current_parts.append(stripped)
+            continue
+
+        _flush()
+
+    _flush()
+    return [point for point in points if point]
+
+
+def _stable_random(*parts: str) -> random.Random:
+    seed_input = "::".join(parts).encode("utf-8")
+    seed = int(hashlib.sha256(seed_input).hexdigest()[:16], 16)
+    return random.Random(seed)
+
+
+def _select_index_for_day(points: list[str], *, day: date) -> int:
+    rng = _stable_random("weakness-point", day.isoformat())
+    return rng.randrange(len(points))
+
+
+def _target_send_at_for_day(
+    *,
+    day: date,
+    config: WeaknessReminderConfig,
+) -> datetime:
+    start_minutes = max(0, config.window_start_hour) * 60
+    end_minutes = max(start_minutes + 1, config.window_end_hour * 60)
+    rng = _stable_random("weakness-send-slot", day.isoformat())
+    minute_offset = rng.randrange(end_minutes - start_minutes)
+    return datetime.combine(day, datetime.min.time()) + timedelta(
+        minutes=start_minutes + minute_offset
+    )
+
+
+def _coach_name() -> str:
+    return os.getenv("COACH_NAME", "Coach").strip() or "Coach"
+
+
+def _build_prompt(*, point: str) -> str:
+    coach_name = _coach_name()
+    lines = [
+        f"You are {coach_name}.",
+        "Send a proactive Telegram coaching message.",
+        (
+            "The user did not type a new message; "
+            "you are initiating the conversation."
+        ),
+        (
+            "This reminder comes from the user's annual review "
+            "and should keep one growth point salient."
+        ),
+        "Use exactly one point from the annual review context below.",
+        (
+            "Lightly reword if that makes the message feel more natural; "
+            "if rewording would distort the meaning or make it complicated, "
+            "keep the original wording."
+        ),
+        (
+            "Telegram supports basic formatting. You may use a short header, "
+            "bold, italics, and bullet points, plus an occasional emoji."
+        ),
+        (
+            "Keep it concise: at most 6 short lines and under 700 characters."
+        ),
+        (
+            "Focus on one point, one reflection, and at most one small action "
+            "or one short question."
+        ),
+        "Annual review point:",
+        point,
+    ]
+    return "\n".join(lines)
+
+
+def build_preview(
+    weakness_file: str | Path,
+    *,
+    day: date | None = None,
+    point_number: int | None = None,
+) -> WeaknessPreview:
+    points = parse_weakness_points(weakness_file)
+    if not points:
+        raise RuntimeError("No top-level weakness reminder points found")
+
+    if point_number is None:
+        current_day = day or datetime.utcnow().date()
+        index = _select_index_for_day(points, day=current_day)
+    else:
+        if point_number < 1 or point_number > len(points):
+            raise ValueError(
+                f"point_number must be between 1 and {len(points)}"
+            )
+        index = point_number - 1
+
+    point = points[index]
+    return WeaknessPreview(
+        point=point,
+        point_number=index + 1,
+        prompt=_build_prompt(point=point),
+    )
+
+
+class WeaknessReminderPlanner:
+    """Deterministic planner for weekday weakness reminders."""
+
+    def __init__(
+        self,
+        db: Session,
+        *,
+        weakness_file: str | Path | None = None,
+        config: WeaknessReminderConfig | None = None,
+        now_fn: Callable[[], datetime] | None = None,
+        repository: ProactiveMessageRepository | None = None,
+    ) -> None:
+        self.db = db
+        self.weakness_file = (
+            Path(weakness_file)
+            if weakness_file is not None
+            else default_weakness_file()
+        )
+        self.config = config or WeaknessReminderConfig.from_env()
+        self.now_fn = now_fn or datetime.utcnow
+        self.repository = repository or ProactiveMessageRepository(db)
+
+    def evaluate(self, *, chat_id: int) -> ProactiveDecision:
+        now = self.now_fn()
+
+        if not self.config.enabled:
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason="Weakness reminder is disabled",
+            )
+
+        if now.weekday() >= 5:
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason=(
+                    "Weekend — weakness reminder only runs Monday to Friday"
+                ),
+            )
+
+        if not self._within_window(now):
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason="Outside configured weakness reminder window",
+            )
+
+        try:
+            preview = build_preview(self.weakness_file, day=now.date())
+        except FileNotFoundError:
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason=f"Weakness file not found: {self.weakness_file}",
+            )
+        except RuntimeError as exc:
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason=str(exc),
+            )
+
+        fingerprint = f"weakness-reflection:{now.date().isoformat()}"
+        existing = self.repository.latest_for_fingerprint(
+            chat_id=chat_id,
+            trigger_fingerprint=fingerprint,
+        )
+        if existing is not None:
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason="Weakness reminder already sent today",
+            )
+
+        target_send_at = _target_send_at_for_day(
+            day=now.date(),
+            config=self.config,
+        )
+        evidence = {
+            "selected_point": preview.point,
+            "selected_point_number": preview.point_number,
+            "target_send_at": target_send_at.isoformat(),
+            "source_file": str(self.weakness_file),
+        }
+
+        if now < target_send_at:
+            return ProactiveDecision.skip(
+                mode=WeaknessReminderMode.SCHEDULED,
+                reason="Today's weakness reminder is not due yet",
+            )
+
+        return ProactiveDecision(
+            should_send=True,
+            mode=WeaknessReminderMode.SCHEDULED,
+            intent=WeaknessReminderIntent.WEAKNESS_REFLECTION,
+            reason="Scheduled annual-review weakness reminder",
+            trigger_fingerprint=fingerprint,
+            evidence=evidence,
+            internal_prompt=preview.prompt,
+        )
+
+    def record_sent(
+        self,
+        *,
+        chat_id: int,
+        decision: ProactiveDecision,
+        telegram_message_id: int | None = None,
+        sent_at: datetime | None = None,
+    ):
+        return self.repository.record_sent(
+            chat_id=chat_id,
+            decision=decision,
+            telegram_message_id=telegram_message_id,
+            sent_at=sent_at,
+        )
+
+    def _within_window(self, now: datetime) -> bool:
+        return (
+            self.config.window_start_hour
+            <= now.hour
+            <= self.config.window_end_hour
+        )
+
+
+async def dispatch_weakness_reminder(
+    *,
+    planner: WeaknessReminderPlanner,
+    chat_id: int,
+    push_fn: Callable[..., Any],
+) -> tuple[ProactiveDecision, Any | None]:
+    """Evaluate, optionally send, and then record a weakness reminder."""
+    decision = planner.evaluate(chat_id=chat_id)
+    if not decision.should_send or not decision.internal_prompt:
+        return decision, None
+
+    result = await push_fn(
+        chat_id=chat_id,
+        prompt=decision.internal_prompt,
+    )
+    planner.record_sent(
+        chat_id=chat_id,
+        decision=decision,
+        telegram_message_id=result.telegram_message_id,
+    )
+    return decision, result

--- a/whoopdata/services/weather_service.py
+++ b/whoopdata/services/weather_service.py
@@ -92,7 +92,7 @@ class WeatherAPI:
 
         data = response.json()
         forecasts = []
-        
+
         # Extract sunrise and sunset from city data
         city_data = data.get("city", {})
         sunrise = city_data.get("sunrise")

--- a/whoopdata/telegram_bot.py
+++ b/whoopdata/telegram_bot.py
@@ -20,9 +20,7 @@ from whoopdata.agent.conversation_service import ConversationService, get_conver
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-_MARKDOWN_TABLE_SEPARATOR_RE = re.compile(
-    r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$"
-)
+_MARKDOWN_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$")
 
 
 def _parse_int_set(raw: str | None) -> set[int]:
@@ -81,7 +79,9 @@ class TelegramConversationGateway:
         self._allowed_chat_ids = set(allowed_chat_ids or ())
         self._bindings_by_chat: dict[int, ConversationBinding] = {}
 
-    def is_authorized(self, *, user_id: int | None, chat_id: int | None, chat_type: str | None) -> bool:
+    def is_authorized(
+        self, *, user_id: int | None, chat_id: int | None, chat_type: str | None
+    ) -> bool:
         if user_id is None or chat_id is None:
             return False
 
@@ -158,7 +158,9 @@ class TelegramConversationGateway:
         transcribed_text = await _transcribe_voice(voice_bytes)
         if not transcribed_text:
             return [
-                OutboundTelegramMessage(text="Sorry, I couldn't understand that voice message. Try again?")
+                OutboundTelegramMessage(
+                    text="Sorry, I couldn't understand that voice message. Try again?"
+                )
             ]
 
         # Get agent response via the normal text path
@@ -196,7 +198,9 @@ class TelegramConversationGateway:
             image_b64=image_b64,
         )
 
-    def _build_response_messages(self, assistant_message: str, artifacts: list) -> list[OutboundTelegramMessage]:
+    def _build_response_messages(
+        self, assistant_message: str, artifacts: list
+    ) -> list[OutboundTelegramMessage]:
         messages: list[OutboundTelegramMessage] = []
 
         if assistant_message:
@@ -285,6 +289,7 @@ def _strip_html_tags(text: str) -> str:
     """Remove HTML tags for TTS input."""
     return re.sub(r"<[^>]+>", "", text)
 
+
 def _strip_markdown_inline_markup(text: str) -> str:
     text = re.sub(r"`([^`\n]+)`", r"\1", text)
     text = re.sub(r"\*\*([^\n*][^*]*?)\*\*", r"\1", text)
@@ -308,10 +313,7 @@ def _normalize_telegram_plain_line(text: str) -> str:
 
 
 def _flatten_markdown_table_row(line: str) -> str:
-    cells = [
-        _normalize_telegram_plain_line(cell)
-        for cell in line.strip().strip("|").split("|")
-    ]
+    cells = [_normalize_telegram_plain_line(cell) for cell in line.strip().strip("|").split("|")]
     cells = [cell for cell in cells if cell]
     if not cells:
         return ""

--- a/whoopdata/telegram_bot.py
+++ b/whoopdata/telegram_bot.py
@@ -20,6 +20,9 @@ from whoopdata.agent.conversation_service import ConversationService, get_conver
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+_MARKDOWN_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$"
+)
 
 
 def _parse_int_set(raw: str | None) -> set[int]:
@@ -281,6 +284,134 @@ async def _attach_voice_replies(
 def _strip_html_tags(text: str) -> str:
     """Remove HTML tags for TTS input."""
     return re.sub(r"<[^>]+>", "", text)
+
+def _strip_markdown_inline_markup(text: str) -> str:
+    text = re.sub(r"`([^`\n]+)`", r"\1", text)
+    text = re.sub(r"\*\*([^\n*][^*]*?)\*\*", r"\1", text)
+    text = re.sub(r"(?<!\*)\*([^\n*][^*]*?)\*(?!\*)", r"\1", text)
+    text = re.sub(r"__([^\n_][^_]*?)__", r"\1", text)
+    text = re.sub(r"(?<!_)_([^\n_][^_]*?)_(?!_)", r"\1", text)
+    return text
+
+
+def _normalize_telegram_plain_line(text: str) -> str:
+    line = text.strip()
+    if not line:
+        return ""
+
+    line = re.sub(r"^#{1,6}\s+", "", line)
+    line = re.sub(r"^\s*[-*]\s+", "• ", line)
+    line = re.sub(r"^\s*\d+[.)]\s+", "• ", line)
+    line = _strip_markdown_inline_markup(line)
+    line = re.sub(r"\s+", " ", line).strip()
+    return line
+
+
+def _flatten_markdown_table_row(line: str) -> str:
+    cells = [
+        _normalize_telegram_plain_line(cell)
+        for cell in line.strip().strip("|").split("|")
+    ]
+    cells = [cell for cell in cells if cell]
+    if not cells:
+        return ""
+    if len(cells) == 2:
+        return f"{cells[0]}: {cells[1]}"
+    return " • ".join(cells)
+
+
+def _truncate_telegram_plain_text(text: str, *, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+
+    truncated = text[:max_chars].rstrip()
+    preferred_cutoff = max_chars // 2
+    cut_positions = (
+        truncated.rfind("\n"),
+        truncated.rfind(". "),
+        truncated.rfind("? "),
+        truncated.rfind("! "),
+        truncated.rfind(" "),
+    )
+    cut_at = max((pos for pos in cut_positions if pos >= preferred_cutoff), default=-1)
+    if cut_at >= 0:
+        pair = truncated[cut_at : cut_at + 2]
+        if pair in {". ", "? ", "! "}:
+            truncated = truncated[: cut_at + 1]
+        else:
+            truncated = truncated[:cut_at]
+
+    return truncated.rstrip(" ,;:-") + "…"
+
+
+def format_text_for_telegram_plain(
+    text: str,
+    *,
+    max_chars: int = 450,
+    max_lines: int = 4,
+) -> str:
+    raw_lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    cleaned_lines: list[str] = []
+    in_code_block = False
+    index = 0
+
+    while index < len(raw_lines):
+        raw_line = raw_lines[index]
+        stripped = raw_line.strip()
+
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            index += 1
+            continue
+
+        if in_code_block:
+            line = _normalize_telegram_plain_line(raw_line)
+            if line:
+                cleaned_lines.append(line)
+            index += 1
+            continue
+
+        if (
+            stripped.count("|") >= 2
+            and index + 1 < len(raw_lines)
+            and _MARKDOWN_TABLE_SEPARATOR_RE.match(raw_lines[index + 1].strip())
+        ):
+            index += 2
+            while index < len(raw_lines):
+                table_line = raw_lines[index].strip()
+                if not table_line or table_line.count("|") < 2:
+                    break
+                flattened = _flatten_markdown_table_row(table_line)
+                if flattened:
+                    cleaned_lines.append(flattened)
+                index += 1
+            continue
+
+        if _MARKDOWN_TABLE_SEPARATOR_RE.match(stripped):
+            index += 1
+            continue
+
+        if stripped.count("|") >= 2:
+            flattened = _flatten_markdown_table_row(stripped)
+            if flattened:
+                cleaned_lines.append(flattened)
+            index += 1
+            continue
+
+        line = _normalize_telegram_plain_line(raw_line)
+        if line:
+            cleaned_lines.append(line)
+        index += 1
+
+    if not cleaned_lines:
+        fallback = _normalize_telegram_plain_line(text) or text.strip()
+        return _truncate_telegram_plain_text(fallback, max_chars=max_chars)
+
+    compact_lines = cleaned_lines[:max_lines]
+    compact = "\n".join(compact_lines)
+    if len(cleaned_lines) > max_lines:
+        compact = compact.rstrip(" ,;:-") + "…"
+    return _truncate_telegram_plain_text(compact, max_chars=max_chars)
 
 
 def format_text_for_telegram_html(text: str) -> str:

--- a/whoopdata/telegram_push.py
+++ b/whoopdata/telegram_push.py
@@ -14,9 +14,13 @@ from dataclasses import dataclass
 
 from dotenv import load_dotenv
 
-from whoopdata.agent.conversation_service import ConversationService, get_conversation_service
+from whoopdata.agent.conversation_service import (
+    ConversationService,
+    get_conversation_service,
+)
 from whoopdata.telegram_bot import (
     format_text_for_telegram_html,
+    format_text_for_telegram_plain,
     session_id_for_chat,
     thread_id_for_chat,
 )
@@ -26,6 +30,9 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_PROACTIVE_FORMAT = (
+    os.getenv("TELEGRAM_PROACTIVE_FORMAT", "plain").strip().lower()
+)
 
 
 @dataclass
@@ -40,6 +47,7 @@ async def push_to_telegram(
     prompt: str,
     conversation_service: ConversationService | None = None,
     bot_token: str | None = None,
+    telegram_format: str | None = None,
 ) -> PushResult:
     """Send a proactive agent message to a Telegram chat.
 
@@ -71,27 +79,28 @@ async def push_to_telegram(
         surface="telegram",
     )
 
-    # Deliver the agent's response to Telegram
+    # Deliver the agent's response to Telegram.
     from telegram import Bot
     from telegram.constants import ParseMode
 
     bot = Bot(token=token)
-    formatted = format_text_for_telegram_html(response.assistant_message)
-    try:
+
+    raw_fmt = telegram_format or TELEGRAM_PROACTIVE_FORMAT or "plain"
+    fmt = raw_fmt.strip().lower()
+    if fmt == "html":
+        formatted = format_text_for_telegram_html(response.assistant_message)
         msg = await bot.send_message(
             chat_id=chat_id,
             text=formatted,
             parse_mode=ParseMode.HTML,
         )
-        telegram_message_id = msg.message_id
-    except Exception:
-        # Fall back to plain text if HTML formatting causes issues
-        logger.warning("HTML send failed, retrying as plain text")
+    else:
+        formatted = format_text_for_telegram_plain(response.assistant_message)
         msg = await bot.send_message(
             chat_id=chat_id,
-            text=response.assistant_message,
+            text=formatted,
         )
-        telegram_message_id = msg.message_id
+    telegram_message_id = msg.message_id
 
     logger.info(
         "Proactive push sent to chat_id=%s, message_id=%s",
@@ -100,6 +109,6 @@ async def push_to_telegram(
     )
 
     return PushResult(
-        assistant_message=response.assistant_message,
+        assistant_message=formatted,
         telegram_message_id=telegram_message_id,
     )

--- a/whoopdata/telegram_push.py
+++ b/whoopdata/telegram_push.py
@@ -30,9 +30,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
-TELEGRAM_PROACTIVE_FORMAT = (
-    os.getenv("TELEGRAM_PROACTIVE_FORMAT", "plain").strip().lower()
-)
+TELEGRAM_PROACTIVE_FORMAT = os.getenv("TELEGRAM_PROACTIVE_FORMAT", "plain").strip().lower()
 
 
 @dataclass
@@ -85,7 +83,7 @@ async def push_to_telegram(
 
     bot = Bot(token=token)
 
-    raw_fmt = telegram_format or TELEGRAM_PROACTIVE_FORMAT or "plain"
+    raw_fmt = telegram_format or "plain"
     fmt = raw_fmt.strip().lower()
     if fmt == "html":
         formatted = format_text_for_telegram_html(response.assistant_message)

--- a/whoopdata/utils/date_filters.py
+++ b/whoopdata/utils/date_filters.py
@@ -4,9 +4,8 @@ Date filtering utilities for consistent datetime handling across different data 
 Handles the complexity of different datetime fields and timezone considerations.
 """
 
-from datetime import datetime, date
+from datetime import datetime
 from typing import Optional, Tuple
-from sqlalchemy import and_
 from sqlalchemy.orm import Query
 
 

--- a/whoopdata/utils/db_loader.py
+++ b/whoopdata/utils/db_loader.py
@@ -76,10 +76,7 @@ class DBLoader:
         if data.get("user_id") and data.get("start"):
             existing = (
                 self.db.query(Cycle)
-                .filter(
-                    Cycle.user_id == data.get("user_id"),
-                    Cycle.start == data.get("start")
-                )
+                .filter(Cycle.user_id == data.get("user_id"), Cycle.start == data.get("start"))
                 .first()
             )
 
@@ -114,9 +111,7 @@ class DBLoader:
         existing = None
         if data.get("whoop_id"):
             existing = (
-                self.db.query(Workout)
-                .filter(Workout.whoop_id == data.get("whoop_id"))
-                .first()
+                self.db.query(Workout).filter(Workout.whoop_id == data.get("whoop_id")).first()
             )
 
         if existing:
@@ -149,11 +144,7 @@ class DBLoader:
         # Check if record already exists (avoid duplicates) using whoop_id
         existing = None
         if data.get("whoop_id"):
-            existing = (
-                self.db.query(Sleep)
-                .filter(Sleep.whoop_id == data.get("whoop_id"))
-                .first()
-            )
+            existing = self.db.query(Sleep).filter(Sleep.whoop_id == data.get("whoop_id")).first()
 
         if existing:
             # Update existing record

--- a/whoopdata/utils/sport_mapping.py
+++ b/whoopdata/utils/sport_mapping.py
@@ -102,13 +102,13 @@ SPORT_ID_MAP = {
 
 def get_sport_name(sport_id: int) -> str:
     """Get human-readable sport name from WHOOP sport ID.
-    
+
     Args:
         sport_id: Integer sport ID from WHOOP API
-        
+
     Returns:
         Human-readable sport name, or "Unknown Sport ({sport_id})" if not found
-        
+
     Examples:
         >>> get_sport_name(0)
         'Running'
@@ -124,13 +124,13 @@ def get_sport_name(sport_id: int) -> str:
 
 def get_sport_id(sport_name: str) -> int | None:
     """Get WHOOP sport ID from sport name (case-insensitive).
-    
+
     Args:
         sport_name: Human-readable sport name
-        
+
     Returns:
         Integer sport ID, or None if not found
-        
+
     Examples:
         >>> get_sport_id("Running")
         0
@@ -146,7 +146,7 @@ def get_sport_id(sport_name: str) -> int | None:
 
 def get_all_sports() -> dict[int, str]:
     """Get complete mapping of all sport IDs to names.
-    
+
     Returns:
         Dictionary mapping sport IDs to sport names
     """
@@ -155,23 +155,37 @@ def get_all_sports() -> dict[int, str]:
 
 def is_cardio_sport(sport_id: int) -> bool:
     """Check if a sport is primarily cardio-based.
-    
+
     Args:
         sport_id: Integer sport ID from WHOOP API
-        
+
     Returns:
         True if sport is cardio-focused, False otherwise
     """
-    cardio_sports = {0, 1, 18, 29, 30, 33, 47, 52, 57, 63, 62, 49, 94}  # Running, Cycling, Rowing, etc.
+    cardio_sports = {
+        0,
+        1,
+        18,
+        29,
+        30,
+        33,
+        47,
+        52,
+        57,
+        63,
+        62,
+        49,
+        94,
+    }  # Running, Cycling, Rowing, etc.
     return sport_id in cardio_sports
 
 
 def is_strength_sport(sport_id: int) -> bool:
     """Check if a sport is primarily strength-based.
-    
+
     Args:
         sport_id: Integer sport ID from WHOOP API
-        
+
     Returns:
         True if sport is strength-focused, False otherwise
     """
@@ -181,36 +195,36 @@ def is_strength_sport(sport_id: int) -> bool:
 
 def get_sport_category(sport_id: int) -> str:
     """Get general category for a sport.
-    
+
     Args:
         sport_id: Integer sport ID from WHOOP API
-        
+
     Returns:
-        Category name: "Cardio", "Strength", "Team Sport", "Racquet Sport", 
+        Category name: "Cardio", "Strength", "Team Sport", "Racquet Sport",
         "Mind-Body", "Recovery", or "Other"
     """
     if sport_id is None:
         return "Unknown"
-        
+
     if is_cardio_sport(sport_id):
         return "Cardio"
     if is_strength_sport(sport_id):
         return "Strength"
-    
+
     # Team sports
     if sport_id in {17, 21, 23, 25, 27, 30, 31, 36, 37, 85, 100, 111, 112}:
         return "Team Sport"
-    
+
     # Racquet sports
     if sport_id in {32, 34, 101, 106}:
         return "Racquet Sport"
-    
+
     # Mind-body
     if sport_id in {43, 44, 70, 230, 231}:
         return "Mind-Body"
-    
+
     # Recovery activities
     if sport_id in {88, 125, 233}:
         return "Recovery"
-    
+
     return "Other"


### PR DESCRIPTION
## Summary\nThis PR improves the coaching agent experience across API and Telegram surfaces, expands the analytics capabilities, and tightens up scheduling and automation for the local services.\n\n## Key changes\n- Enhances agent conversation handling and public surface contracts, with updated routing and response shaping.\n- Extends analytics (pipelines, models and endpoints) and adds new analysis helpers for more actionable insights.\n- Improves proactive coaching and reminder workflows, including scheduled jobs and Telegram push/bot behaviour.\n- Adds verification and test coverage across the updated surfaces.\n\n## How to test\n- Run the test suite: ============================= test session starts ==============================
platform darwin -- Python 3.11.11, pytest-9.0.2, pluggy-1.6.0 -- /Users/home/Documents/Projects/whoop-data/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/home/Documents/Projects/whoop-data
configfile: pyproject.toml
testpaths: tests
plugins: langsmith-0.7.19, anyio-4.12.1, cov-7.0.0
collecting ... collected 181 items

tests/test_agent_architecture.py::TestAgentRegistry::test_registry_has_entries PASSED [  0%]
tests/test_agent_architecture.py::TestAgentRegistry::test_required_keys_present PASSED [  1%]
tests/test_agent_architecture.py::TestAgentRegistry::test_name_matches_key PASSED [  1%]
tests/test_agent_architecture.py::TestAgentRegistry::test_descriptions_are_non_empty PASSED [  2%]
tests/test_agent_architecture.py::TestAgentRegistry::test_system_prompts_are_non_empty PASSED [  2%]
tests/test_agent_architecture.py::TestAgentRegistry::test_tool_lists_are_non_empty PASSED [  3%]
tests/test_agent_architecture.py::TestAgentRegistry::test_all_tool_names_resolve PASSED [  3%]
tests/test_agent_architecture.py::TestToolGrouping::test_no_tool_in_multiple_data_specialists PASSED [  4%]
tests/test_agent_architecture.py::TestToolGrouping::test_all_api_tools_assigned PASSED [  4%]
tests/test_agent_architecture.py::TestToolsLookup::test_tools_by_name_populated PASSED [  5%]
tests/test_agent_architecture.py::TestToolsLookup::test_tools_by_name_matches_available_tools PASSED [  6%]
tests/test_agent_architecture.py::TestToolsLookup::test_python_repl_in_tools_by_name PASSED [  6%]
tests/test_agent_architecture.py::TestSpecialistFactory::test_returns_tools_for_each_registry_entry PASSED [  7%]
tests/test_agent_architecture.py::TestSpecialistFactory::test_tools_are_base_tool_instances PASSED [  7%]
tests/test_agent_architecture.py::TestSpecialistFactory::test_tool_names_match_registry PASSED [  8%]
tests/test_agent_architecture.py::TestSpecialistFactory::test_tool_descriptions_non_empty PASSED [  8%]
tests/test_agent_architecture.py::TestSpecialistFactory::test_create_agent_called_for_each_specialist PASSED [  9%]
tests/test_agent_architecture.py::TestExtractFinalResponse::test_extracts_last_ai_message PASSED [  9%]
tests/test_agent_architecture.py::TestExtractFinalResponse::test_returns_fallback_for_empty_messages PASSED [ 10%]
tests/test_agent_architecture.py::TestPrompts::test_supervisor_prompt_exists PASSED [ 11%]
tests/test_agent_architecture.py::TestPrompts::test_supervisor_prompt_mentions_specialists PASSED [ 11%]
tests/test_agent_architecture.py::TestPrompts::test_supervisor_prompt_includes_day_of_briefing_instruction PASSED [ 12%]
tests/test_agent_architecture.py::TestPrompts::test_exercise_prompt_file_exists PASSED [ 12%]
tests/test_agent_architecture.py::TestPrompts::test_behaviour_change_prompt_file_exists PASSED [ 13%]
tests/test_agent_architecture.py::TestGraphBuild::test_build_graph_returns_compiled_graph PASSED [ 13%]
tests/test_agent_architecture.py::TestGraphBuild::test_build_graph_supervisor_gets_specialist_tools_plus_direct_tools PASSED [ 14%]
tests/test_agent_architecture.py::TestGraphBuild::test_build_graph_has_single_langgraph_config_parameter PASSED [ 14%]
tests/test_agent_architecture.py::TestGraphBuild::test_build_graph_accepts_langgraph_config_and_uses_its_checkpointer PASSED [ 15%]
tests/test_agent_conversation_service.py::test_start_conversation_reuses_existing_session_thread_mapping PASSED [ 16%]
tests/test_agent_conversation_service.py::test_send_message_uses_existing_session_thread_and_shapes_response PASSED [ 16%]
tests/test_agent_conversation_service.py::test_send_message_respects_explicit_thread_id_without_existing_session PASSED [ 17%]
tests/test_agent_conversation_service.py::test_send_message_reuses_same_thread_for_session_resume PASSED [ 17%]
tests/test_agent_conversation_service.py::test_send_message_isolates_distinct_conversations_by_thread PASSED [ 18%]
tests/test_agent_conversation_service.py::test_ensure_graph_passes_checkpointer_and_store_with_langgraph_keys PASSED [ 18%]
tests/test_agent_memory_tools.py::test_manage_memory_create_update_delete_and_search PASSED [ 19%]
tests/test_agent_memory_tools.py::test_manage_memory_uses_canonical_profile_key PASSED [ 19%]
tests/test_agent_routes.py::test_create_conversation_route_uses_shared_service_dependency PASSED [ 20%]
tests/test_agent_routes.py::test_send_message_route_returns_conversation_response PASSED [ 20%]
tests/test_agent_routes.py::test_send_message_route_maps_service_errors_to_http_500 PASSED [ 21%]
tests/test_app_composition.py::test_main_module_is_composition_only PASSED [ 22%]
tests/test_app_composition.py::test_router_groups_are_declared_by_surface PASSED [ 22%]
tests/test_app_composition.py::test_page_routes_are_owned_by_dedicated_web_modules PASSED [ 23%]
tests/test_app_composition.py::test_withings_status_route_is_owned_by_dedicated_router PASSED [ 23%]
tests/test_app_composition.py::test_agent_routes_are_owned_by_dedicated_agent_router PASSED [ 24%]
tests/test_chat_app_boundary.py::test_chat_app_defers_conversation_id_creation_to_shared_boundary PASSED [ 24%]
tests/test_chat_app_boundary.py::test_chat_app_reuses_existing_conversation_ids_on_follow_up_messages PASSED [ 25%]
tests/test_chat_app_boundary.py::test_chat_app_formats_boundary_artifacts_for_gradio PASSED [ 25%]
tests/test_conversation_service.py::test_build_human_message_text_only PASSED [ 26%]
tests/test_conversation_service.py::test_build_human_message_with_image PASSED [ 27%]
tests/test_conversation_service.py::test_build_human_message_none_image_returns_text PASSED [ 27%]
tests/test_daily_engine.py::TestDailySchemas::test_recovery_status_green PASSED [ 28%]
tests/test_daily_engine.py::TestDailySchemas::test_recovery_status_red PASSED [ 28%]
tests/test_daily_engine.py::TestDailySchemas::test_daily_action_fields PASSED [ 29%]
tests/test_daily_engine.py::TestDailySchemas::test_sleep_target PASSED   [ 29%]
tests/test_daily_engine.py::TestDailySchemas::test_context_summary_optional PASSED [ 30%]
tests/test_daily_engine.py::TestDailySchemas::test_daily_plan_response PASSED [ 30%]
tests/test_daily_engine.py::TestScenarioSchemas::test_scenario_input_validation PASSED [ 31%]
tests/test_daily_engine.py::TestScenarioSchemas::test_scenario_input_with_label PASSED [ 32%]
tests/test_daily_engine.py::TestScenarioSchemas::test_scenario_result PASSED [ 32%]
tests/test_daily_engine.py::TestScenarioSchemas::test_compare_request_min_scenarios PASSED [ 33%]
tests/test_daily_engine.py::TestPersonas::test_default_persona_exists PASSED [ 33%]
tests/test_daily_engine.py::TestPersonas::test_all_personas_have_required_keys PASSED [ 34%]
tests/test_daily_engine.py::TestPersonas::test_get_system_prompt_returns_string PASSED [ 34%]
tests/test_daily_engine.py::TestPersonas::test_get_action_text PASSED    [ 35%]
tests/test_daily_engine.py::TestPersonas::test_unknown_persona_falls_back_to_default PASSED [ 35%]
tests/test_daily_engine.py::TestPersonas::test_list_personas PASSED      [ 36%]
tests/test_daily_engine.py::TestActionGeneration::test_green_recovery_produces_training_action PASSED [ 37%]
tests/test_daily_engine.py::TestActionGeneration::test_red_recovery_produces_rest_action PASSED [ 37%]
tests/test_daily_engine.py::TestActionGeneration::test_hrv_high_produces_positive_action PASSED [ 38%]
tests/test_daily_engine.py::TestActionGeneration::test_hrv_low_produces_easy_action PASSED [ 38%]
tests/test_daily_engine.py::TestActionGeneration::test_sleep_deficit_produces_sleep_action PASSED [ 39%]
tests/test_daily_engine.py::TestActionGeneration::test_weather_aqi_warning PASSED [ 39%]
tests/test_docs_and_openapi_guidance.py::test_openapi_publishes_top_level_surface_tag_metadata PASSED [ 40%]
tests/test_docs_and_openapi_guidance.py::test_readme_and_makefile_distinguish_surfaces_and_run_modes PASSED [ 40%]
tests/test_docs_and_openapi_guidance.py::test_readme_includes_rollout_verification_checklist PASSED [ 41%]
tests/test_insight_service_extraction.py::test_guidance_service_builds_daily_plan_from_shared_context PASSED [ 41%]
tests/test_insight_service_extraction.py::test_dashboard_service_composes_context_outside_router PASSED [ 42%]
tests/test_insight_service_extraction.py::test_dashboard_daily_route_delegates_to_dashboard_service PASSED [ 43%]
tests/test_insight_service_extraction.py::test_dashboard_support_routes_delegate_to_dashboard_service PASSED [ 43%]
tests/test_insight_service_extraction.py::test_daily_routes_delegate_to_guidance_service PASSED [ 44%]
tests/test_legacy_route_deprecation.py::test_legacy_route_openapi_includes_replacement_and_removal_metadata[/recovery/latest-GET] PASSED [ 44%]
tests/test_legacy_route_deprecation.py::test_legacy_route_openapi_includes_replacement_and_removal_metadata[/workouts/latest-GET] PASSED [ 45%]
tests/test_legacy_route_deprecation.py::test_legacy_route_openapi_includes_replacement_and_removal_metadata[/dashboard/daily-GET] PASSED [ 45%]
tests/test_legacy_route_deprecation.py::test_legacy_route_openapi_includes_replacement_and_removal_metadata[/api/daily-plan-GET] PASSED [ 46%]
tests/test_legacy_route_deprecation.py::test_legacy_route_responses_emit_deprecation_headers[/recovery/latest-GET] PASSED [ 46%]
tests/test_legacy_route_deprecation.py::test_legacy_route_responses_emit_deprecation_headers[/workouts/latest-GET] PASSED [ 47%]
tests/test_legacy_route_deprecation.py::test_legacy_route_responses_emit_deprecation_headers[/dashboard/daily-GET] PASSED [ 48%]
tests/test_legacy_route_deprecation.py::test_legacy_route_responses_emit_deprecation_headers[/api/daily-plan-GET] PASSED [ 48%]
tests/test_mlr.py::TestBuildRecoveryMLR::test_basic_merge PASSED         [ 49%]
tests/test_mlr.py::TestBuildRecoveryMLR::test_output_dtypes_are_numeric PASSED [ 49%]
tests/test_mlr.py::TestBuildRecoveryMLR::test_no_nan_in_core_features PASSED [ 50%]
tests/test_mlr.py::TestBuildRecoveryMLR::test_empty_workouts_handled PASSED [ 50%]
tests/test_mlr.py::TestBuildRecoveryMLR::test_object_dtype_columns_coerced PASSED [ 51%]
tests/test_mlr.py::TestBuildRecoveryMLR::test_none_values_in_numeric_columns PASSED [ 51%]
tests/test_mlr.py::TestFitRecoveryMLR::test_fit_returns_model PASSED     [ 52%]
tests/test_mlr.py::TestFitRecoveryMLR::test_model_params_length PASSED   [ 53%]
tests/test_mlr.py::TestFitRecoveryMLR::test_r_squared_range PASSED       [ 53%]
tests/test_mlr.py::TestFitRecoveryMLR::test_insufficient_data_returns_none PASSED [ 54%]
tests/test_mlr.py::TestFitRecoveryMLR::test_constant_column_no_crash PASSED [ 54%]
tests/test_mlr.py::TestGetRecoveryResults::test_result_keys PASSED       [ 55%]
tests/test_mlr.py::TestGetRecoveryResults::test_coef_df_columns PASSED   [ 55%]
tests/test_mlr.py::TestGetRecoveryResults::test_p_values_in_range PASSED [ 56%]
tests/test_mlr.py::TestGetRecoveryResults::test_partial_corr_in_range PASSED [ 56%]
tests/test_mlr.py::TestGetRecoveryResults::test_n_observations PASSED    [ 57%]
tests/test_mlr.py::TestMLRSerialisation::test_serialisation_produces_plain_types PASSED [ 58%]
tests/test_mlr.py::TestMLRSerialisation::test_serialisation_is_json_safe PASSED [ 58%]
tests/test_mlr.py::TestBuildHRVMLR::test_basic_merge PASSED              [ 59%]
tests/test_mlr.py::TestBuildHRVMLR::test_workout_aggregation PASSED      [ 59%]
tests/test_mlr.py::TestFitHRVMLR::test_fit_returns_model PASSED          [ 60%]
tests/test_mlr.py::TestFitHRVMLR::test_available_optional_features PASSED [ 60%]
tests/test_mlr.py::TestFitHRVMLR::test_insufficient_data PASSED          [ 61%]
tests/test_mlr.py::TestGetHRVResults::test_result_keys PASSED            [ 61%]
tests/test_mlr.py::TestGetHRVResults::test_serialisation PASSED          [ 62%]
tests/test_mlr.py::TestEdgeCases::test_all_nan_column_in_sleep PASSED    [ 62%]
tests/test_mlr.py::TestEdgeCases::test_integer_columns_as_object PASSED  [ 63%]
tests/test_mlr.py::TestEdgeCases::test_empty_dataframes PASSED           [ 64%]
tests/test_mlr.py::TestCorrelationMatrix::test_matrix_is_square PASSED   [ 64%]
tests/test_mlr.py::TestCorrelationMatrix::test_values_in_range PASSED    [ 65%]
tests/test_proactive_coach.py::test_hidden_load_trigger_fires_for_high_strain_with_only_walking_workouts PASSED [ 65%]
tests/test_proactive_coach.py::test_running_gap_trigger_uses_activity_adherence_first PASSED [ 66%]
tests/test_proactive_coach.py::test_stale_weight_trigger_fires_when_measurement_is_old PASSED [ 66%]
tests/test_proactive_coach.py::test_repeated_gap_escalates_to_barrier_resolution PASSED [ 67%]
tests/test_proactive_coach.py::test_morning_mode_falls_back_to_briefing_when_no_other_trigger_fires PASSED [ 67%]
tests/test_proactive_coach.py::test_dispatch_records_sent_message PASSED [ 68%]
tests/test_proactive_scripts.py::test_scheduled_proactive_returns_true_when_planner_skips PASSED [ 69%]
tests/test_proactive_scripts.py::test_scheduled_morning_returns_true_when_planner_skips PASSED [ 69%]
tests/test_proactive_scripts.py::test_post_etl_hook_returns_true_when_disabled PASSED [ 70%]
tests/test_proactive_scripts.py::test_post_etl_hook_uses_window_dispatch_when_enabled PASSED [ 70%]
tests/test_protein_tool.py::test_protein_recommendation[asyncio] PASSED  [ 71%]
tests/test_public_response_contract.py::test_response_contracts_cover_all_public_surfaces PASSED [ 71%]
tests/test_public_response_contract.py::test_agent_conversation_response_hides_raw_langgraph_state PASSED [ 72%]
tests/test_public_surface_contract.py::test_contract_defines_expected_surfaces_and_namespaces PASSED [ 72%]
tests/test_public_surface_contract.py::test_route_inventory_conforms_to_public_surface_contract PASSED [ 73%]
tests/test_public_surface_contract.py::test_runtime_entrypoints_conform_to_surface_contract PASSED [ 74%]
tests/test_public_surface_contract.py::test_contract_exposes_rules_for_all_surfaces PASSED [ 74%]
tests/test_public_surface_inventory.py::test_route_inventory_matches_fastapi_public_surface PASSED [ 75%]
tests/test_public_surface_inventory.py::test_route_targets_match_surface_prefix_rules PASSED [ 75%]
tests/test_public_surface_inventory.py::test_canonical_data_routes_are_not_deprecated PASSED [ 76%]
tests/test_public_surface_inventory.py::test_legacy_raw_data_routes_are_explicitly_deprecated PASSED [ 76%]
tests/test_public_surface_inventory.py::test_canonical_insight_routes_are_not_deprecated PASSED [ 77%]
tests/test_public_surface_inventory.py::test_canonical_agent_routes_are_not_deprecated PASSED [ 77%]
tests/test_public_surface_inventory.py::test_legacy_insight_routes_are_explicitly_deprecated PASSED [ 78%]
tests/test_public_surface_inventory.py::test_temporary_legacy_adapters_include_migration_guidance PASSED [ 79%]
tests/test_public_surface_inventory.py::test_project_script_inventory_matches_pyproject_scripts PASSED [ 79%]
tests/test_public_surface_inventory.py::test_runtime_entrypoints_reference_existing_files_and_targets PASSED [ 80%]
tests/test_recovery_actionability_integration.py::test_recovery_actionability_endpoint_404_when_missing PASSED [ 80%]
tests/test_recovery_actionability_integration.py::test_recovery_actionability_endpoint_returns_payload PASSED [ 81%]
tests/test_recovery_actionability_integration.py::test_daily_engine_injects_actionability_sentence PASSED [ 81%]
tests/test_recovery_actionability_integration.py::test_proactive_morning_briefing_includes_actionability_in_evidence PASSED [ 82%]
tests/test_telegram_bot_boundary.py::test_gateway_rejects_group_messages_even_without_allowlists PASSED [ 82%]
tests/test_telegram_bot_boundary.py::test_gateway_reuses_conversation_binding_per_chat PASSED [ 83%]
tests/test_telegram_bot_boundary.py::test_gateway_formats_code_and_image_artifacts_for_telegram PASSED [ 83%]
tests/test_telegram_bot_boundary.py::test_whoami_message_includes_ids_for_first_run_setup PASSED [ 84%]
tests/test_telegram_bot_boundary.py::test_gateway_photo_message_sends_image_b64 PASSED [ 85%]
tests/test_telegram_bot_boundary.py::test_gateway_photo_message_uses_default_caption_when_none PASSED [ 85%]
tests/test_telegram_bot_boundary.py::test_gateway_photo_message_rejected_for_unauthorized_user PASSED [ 86%]
tests/test_telegram_bot_boundary.py::test_gateway_voice_message_returns_error_on_transcription_failure PASSED [ 86%]
tests/test_telegram_bot_boundary.py::test_gateway_voice_message_transcribes_and_delegates PASSED [ 87%]
tests/test_telegram_bot_boundary.py::test_gateway_voice_message_rejected_for_unauthorized_user PASSED [ 87%]
tests/test_telegram_bot_boundary.py::test_gateway_formats_markdownish_assistant_text_for_telegram_html PASSED [ 88%]
tests/test_telegram_bot_boundary.py::test_plain_formatter_flattens_markdown_tables_for_chat_style_delivery PASSED [ 88%]
tests/test_telegram_bot_boundary.py::test_plain_formatter_limits_length_and_line_count PASSED [ 89%]
tests/test_telegram_push.py::test_push_to_telegram_sends_compact_plain_text PASSED [ 90%]
tests/test_weakness_reminder.py::test_parse_weakness_points_ignores_non_top_level_items PASSED [ 90%]
tests/test_weakness_reminder.py::test_weekday_evaluation_uses_stable_point_and_due_slot PASSED [ 91%]
tests/test_weakness_reminder.py::test_weekend_evaluation_skips_send PASSED [ 91%]
tests/test_weakness_reminder.py::test_recorded_send_skips_later_attempts_on_the_same_workday PASSED [ 92%]
tests/test_weakness_reminder.py::test_internal_prompt_locks_point_and_rewording_contract PASSED [ 92%]
tests/test_weakness_reminder.py::test_build_preview_can_target_a_specific_top_level_point PASSED [ 93%]
tests/test_weakness_reminder.py::test_dispatch_records_sent_message_for_the_selected_point PASSED [ 93%]
tests/test_weakness_scripts.py::test_scheduled_weakness_returns_true_when_planner_skips PASSED [ 94%]
tests/test_weakness_scripts.py::test_send_preview_pushes_selected_point PASSED [ 95%]
tests/test_whoop_headless_refresh.py::test_analysis_client_credentials_persists_refresh_metadata PASSED [ 95%]
tests/test_whoop_headless_refresh.py::test_legacy_client_auth_url_requests_offline_scope PASSED [ 96%]
tests/test_whoop_headless_refresh.py::test_scheduled_etl_audit_entry_summarizes_results PASSED [ 96%]
tests/test_whoop_headless_refresh.py::test_scheduled_etl_appends_json_line PASSED [ 97%]
tests/test_whoop_v2_migration.py::test_all_maintained_whoop_clients_use_v2_endpoints PASSED [ 97%]
tests/test_whoop_v2_migration.py::test_legacy_client_maps_v2_zone_durations_fields PASSED [ 98%]
tests/test_whoop_v2_migration.py::test_transform_sleep_handles_v2_uuid_ids PASSED [ 98%]
tests/test_whoop_v2_migration.py::test_transform_workout_handles_v2_uuid_ids PASSED [ 99%]
tests/test_whoop_v2_migration.py::test_custom_gpt_workout_spec_uses_v2_and_uuid_ids PASSED [100%]

=============================== warnings summary ===============================
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:64
  /Users/home/Documents/Projects/whoop-data/.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:64: PyparsingDeprecationWarning: 'oneOf' deprecated - use 'one_of'
    prop = Group((name + Suppress("=") + comma_separated(value)) | oneOf(_CONSTANTS))

.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85
  /Users/home/Documents/Projects/whoop-data/.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:85: PyparsingDeprecationWarning: 'parseString' deprecated - use 'parse_string'
    parse = parser.parseString(pattern)

.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89
.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89
  /Users/home/Documents/Projects/whoop-data/.venv/lib/python3.11/site-packages/matplotlib/_fontconfig_pattern.py:89: PyparsingDeprecationWarning: 'resetCache' deprecated - use 'reset_cache'
    parser.resetCache()

.venv/lib/python3.11/site-packages/matplotlib/_mathtext.py:45
  /Users/home/Documents/Projects/whoop-data/.venv/lib/python3.11/site-packages/matplotlib/_mathtext.py:45: PyparsingDeprecationWarning: 'enablePackrat' deprecated - use 'enable_packrat'
    ParserElement.enablePackrat()

.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295
.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295
.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295
  /Users/home/Documents/Projects/whoop-data/.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

.venv/lib/python3.11/site-packages/websockets/legacy/__init__.py:6
  /Users/home/Documents/Projects/whoop-data/.venv/lib/python3.11/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
    warnings.warn(  # deprecated in 14.0 - 2024-11-09

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 181 passed, 18 warnings in 8.65s =======================\n- Bring services up/down: 🛑 Removing launchd services...
✅ All whoopdata services removed
📅 Installing launchd services...
✅ Installed: persistent FastAPI server + Telegram bot + recurring ETL + daily morning job + proactive window evaluator + weakness reminder evaluator
   Check with: make schedule-test\n- Trigger a morning run manually: ☀️ Running morning ETL + push now...
uv run python scripts/scheduled_morning.py
╭─────────────────────────────────────────╮
│ 🚀 Complete Health Data ETL Pipeline 🚀 │
│ Mode: Incremental                       │
╰─────────────────────────────────────────╯

📅 Fetch Windows:
   • recovery: 2026-03-27 to 2026-03-28
   • sleep: 2026-03-27 to 2026-03-28
   • workout: 2026-03-27 to 2026-03-28
   • cycle: 2026-03-27 to 2026-03-28
   • withings_weight: 2026-03-22 to 2026-03-28
   • withings_heart_rate: 2026-03-22 to 2026-03-28

============================================================
WHOOP Data Pipeline
============================================================
🔄 Starting WHOOP sleep ETL...
Using existing access token
📅 Getting data from https://api.prod.whoop.com/developer/v2/activity/sleep (from 2026-03-27T07:38:28.075Z to 2026-03-28T11:36:31.335Z)
Retrieved 1 records
🎯 Detected endpoint type: 'sleep'
🔄 Transforming 1 sleep records for database compatibility...
✅ Transformation complete. Available fields: ['id', 'cycle_id', 'v1_id', 'user_id', 'created_at', 'updated_at', 'start', 'end', 'timezone_offset', 'nap', 'score_state', 'total_time_in_bed_time_milli', 'total_awake_time_milli', 'total_no_data_time_milli', 'score.stage_summary.total_light_sleep_time_milli', 'total_slow_wave_sleep_time_milli', 'total_rem_sleep_time_milli', 'sleep_cycle_count', 'disturbance_count', 'baseline_sleep_needed_milli', 'need_from_sleep_debt_milli', 'need_from_recent_strain_milli', 'need_from_recent_nap_milli', 'respiratory_rate', 'sleep_performance_percentage', 'sleep_consistency_percentage', 'sleep_efficiency_percentage']
📊 Processing 1 sleep records...
✅ WHOOP sleep: 1 successful, 0 errors
🔄 Starting WHOOP strain ETL...
Using existing access token
📅 Getting data from https://api.prod.whoop.com/developer/v2/cycle (from 2026-03-27T07:38:22.897Z to 2026-03-28T11:36:31.335Z)
Retrieved 2 records
🎯 Detected endpoint type: 'cycle'
🔄 Transforming 2 cycle records for database compatibility...
✅ Transformation complete. Available fields: ['id', 'user_id', 'created_at', 'updated_at', 'start', 'end', 'timezone_offset', 'score_state', 'strain', 'kilojoule', 'average_heart_rate', 'max_heart_rate']
📊 Processing 2 strain records...
✅ WHOOP strain: 2 successful, 0 errors
🔄 Starting WHOOP workout ETL...
Using existing access token
📅 Getting data from https://api.prod.whoop.com/developer/v2/activity/workout (from 2026-03-27T09:19:26.800Z to 2026-03-28T11:36:31.335Z)
Retrieved 2 records
🎯 Detected endpoint type: 'workout'
🔄 Transforming 2 workout records for database compatibility...
✅ Transformation complete. Available fields: ['id', 'v1_id', 'user_id', 'created_at', 'updated_at', 'start', 'end', 'timezone_offset', 'sport_name', 'score_state', 'strain', 'average_heart_rate', 'max_heart_rate', 'kilojoule', 'percent_recorded', 'distance_meter', 'altitude_gain_meter', 'altitude_change_meter', 'zone_zero_minutes', 'zone_one_minutes', 'zone_two_minutes', 'zone_three_minutes', 'zone_four_minutes', 'zone_five_minutes', 'sport_id']
📊 Processing 2 workout records...
✅ WHOOP workout: 2 successful, 0 errors
🔄 Starting WHOOP recovery ETL...
Using existing access token
📅 Getting data from https://api.prod.whoop.com/developer/v2/recovery (from 2026-03-27T07:38:28.075Z to 2026-03-28T11:36:31.335Z)
Retrieved 1 records
🎯 Detected endpoint type: 'recovery'
🔄 Transforming 1 recovery records for database compatibility...
✅ Transformation complete. Available fields: ['cycle_id', 'sleep_id', 'user_id', 'created_at', 'updated_at', 'score_state', 'user_calibrating', 'recovery_score', 'resting_heart_rate', 'hrv_rmssd_milli', 'spo2_percentage', 'skin_temp_celsius']
📊 Processing 1 recovery records...
✅ WHOOP recovery: 1 successful, 0 errors

============================================================
Withings Data Pipeline
============================================================
🏥 Starting Withings weight ETL...
✅ Using existing Withings access token
📊 Processing 4 weight/body composition records...
🕒 Withings weight recency — API newest: 2026-03-23 07:05:31, DB newest: 2026-03-23 07:05:31
✅ Withings weight: 1 successful, 0 errors
🏥 Starting Withings heart_rate ETL...
✅ Using existing Withings access token
📊 Processing 1 heart rate/BP records...
✅ Withings heart_rate: 1 successful, 0 errors

============================================================
ETL Pipeline Summary
============================================================
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┓
┃ Data Source          ┃ Successful ┃ Errors ┃   Status   ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━┩
│ Whoop Sleep          │     1      │   0    │ ✅ Success │
│ Whoop Cycle          │     2      │   0    │ ✅ Success │
│ Whoop Workout        │     2      │   0    │ ✅ Success │
│ Whoop Recovery       │     1      │   0    │ ✅ Success │
│ Withings Weight      │     1      │   0    │ ✅ Success │
│ Withings Heart Rate  │     1      │   0    │ ✅ Success │
└──────────────────────┴────────────┴────────┴────────────┘

Total Records Processed: 8
Successfully Loaded: 8
Errors: 0

============================================================
Sample Data Overview
============================================================
🔋 Latest Recovery: Score: 56.0, RHR: 56.0, Category: Yellow
⚖️  Latest Weight: 70.675kg, BMI: None, Category: Unknown
💪 Latest Workout: Strain: 5.3734417, Duration: 33min

📊 Database Summary:
   • Recovery Records: 870
   • Workout Records: 2357
   • Sleep Records: 881
   • Weight Records: 115
   • Heart Rate Records: 96\n\n## Notes\n- If you want durable agent memory across restarts, ensure  is configured (otherwise the fallback is in-memory).\n\nCo-Authored-By: Oz <oz-agent@warp.dev>