### PR TITLE
AGE-57..61: stabilize routing and tool wiring

### DIFF
--- a/data/prompts/agents/supervisor.md
+++ b/data/prompts/agents/supervisor.md
@@ -22,13 +22,16 @@ You have specialist teams you delegate to — use them:
 - **environment** — Weather, air quality, forecasts, London transport, Thames tides  
 - **exercise** — Training program design, periodized programming, FITT-VP exercise prescriptions
 - **behaviour_change** — Habit coaching using COM-B framework, barrier analysis, adherence support
+- **nutrition** — Protein targets, macro guidance, dietary recommendations
 
 **Key distinction:** health_data for "show me" queries, analytics for "why" and "predict" queries.
+Routing tie-breakers for overlap:
+- If the user asks to improve sleep and wants metrics/trends, use **health_data**. If they want habit/adherence coaching, use **behaviour_change**.
+- If the user asks about weight loss and wants diet/macros/protein guidance, use **nutrition**. If they want motivation/adherence coaching, use **behaviour_change**.
 
 When a specialist returns structured planning content (exercise plans, behaviour change plans), render it in YOUR voice — keep the persona consistent. You are always the one talking to the user.
 
 You also have direct access to:
-- **get_protein_recommendation** — Calculate protein targets automatically from Withings weight (just needs activity level)
 - **Python interpreter** — For data visualisation and custom calculations
 - **search_memory** — Look up durable user memory in categories like profile, goals, constraints, commitments, and observations
 - **manage_memory** — Create, update, or delete durable user memory when the user shares stable personal context or corrects prior memory

--- a/whoopdata/agent/README.md
+++ b/whoopdata/agent/README.md
@@ -82,7 +82,8 @@ metrics, and landmarks saved locally for review.
 
 For text-based follow-ups ("what drills fix that hip rotation?"), the
 supervisor routes to the `biomechanics` specialist tool registered in the
-agent registry, which searches memory for the previous video analysis.
+agent registry, which can both search durable memory and pull workout
+context (tennis and general workout tools) for grounded recommendations.
 
 ## Module Map
 
@@ -120,6 +121,40 @@ The `specialist_default` entry is the fallback for any specialist not
 explicitly listed. To override a specialist's model, add or edit its named
 entry in `LLM_CONFIG`.
 
+Current routing consistency policy aligns specialist temperatures to `0.1`
+to reduce variance in equivalent query paths.
+
+## Routing Ownership Notes
+
+- Protein/macro/dietary guidance routes through the `nutrition` specialist.
+- The supervisor does not directly call the protein recommendation tool.
+- `health_data` focuses on metric retrieval/summaries; `behaviour_change`
+  focuses on adherence/motivation coaching.
+
+## Tool Surface (High-Level)
+
+The tool layer is intentionally broad, but it is organized into clear domains
+so routing stays understandable:
+
+- **Health data retrieval tools** -- WHOOP and Withings record access
+  (recovery, sleep, workouts, body metrics, heart-rate/vitals, and summaries).
+- **Analytics tools** -- deeper analysis and modeling utilities
+  (factor importance, correlations, trends, and prediction endpoints).
+- **Environment/context tools** -- weather, air quality, forecast, transport,
+  tide, and outdoor planning context.
+- **Coaching support tools** -- nutrition/protein recommendation logic and
+  specialist-specific plan-generation support.
+- **Memory tools** -- durable coaching memory:
+  - `search_memory` for retrieving relevant user context
+  - `manage_memory` for create/update/delete of durable facts
+- **Computation tool** -- Python interpreter for custom calculations and
+  chart generation when structured analysis is needed.
+
+Design intent:
+- Specialists receive domain-scoped subsets of these tools from
+  `whoopdata/agent/registry.py`.
+- The supervisor gets specialist wrappers plus a small set of direct tools
+  (Python interpreter + memory tools) for orchestration and synthesis.
 ## Memory
 
 The agent uses LangGraph's store abstraction for durable memory. Categories:

--- a/whoopdata/agent/graph.py
+++ b/whoopdata/agent/graph.py
@@ -16,7 +16,7 @@ from .schemas import AgentConfig, HealthContextSchema
 from .model_config_loader import get_supervisor_model_config
 from .model_factory import build_chat_model
 from .specialists import build_specialist_tools
-from .tools import python_repl_tool, get_protein_recommendation_tool
+from .tools import python_repl_tool
 
 CONFIG_KEY_STORE = "__store"
 
@@ -104,7 +104,6 @@ def _create_graph(*, checkpointer: Any | None = None, store: Any | None = None):
         specialist_tools
         + [
             python_repl_tool,
-            get_protein_recommendation_tool,
             search_memory,
             manage_memory,
         ]

--- a/whoopdata/agent/registry.py
+++ b/whoopdata/agent/registry.py
@@ -57,6 +57,7 @@ AGENT_REGISTRY: dict[str, dict] = {
         ),
         "tools": [
             "get_recovery_data",
+            "get_top_recoveries",
             "get_sleep_data",
             "get_workout_data",
             "get_running_workouts",
@@ -66,7 +67,6 @@ AGENT_REGISTRY: dict[str, dict] = {
             "get_heart_rate_data",
             "get_withings_summary",
             "get_recovery_trends",
-            "get_protein_recommendation",
         ],
     },
     "analytics": {
@@ -138,7 +138,8 @@ AGENT_REGISTRY: dict[str, dict] = {
             "Behaviour change coaching using COM-B framework and Behaviour Change Techniques. "
             "Covers goal setting, action planning, barrier analysis, habit formation, "
             "motivation support, and relapse prevention. "
-            "Use this when the user is struggling with adherence, motivation, or forming habits."
+            "Use this when the user is struggling with adherence, motivation, or forming habits. "
+            "Do not use this for raw metric retrieval requests."
         ),
         "system_prompt": _load_prompt("behaviour_change_sub_agent.md"),
         "tools": [
@@ -153,7 +154,7 @@ AGENT_REGISTRY: dict[str, dict] = {
         "description": (
             "Nutrition guidance and protein intake recommendations. "
             "Calculates personalized protein targets based on current weight and activity level. "
-            "Use this when the user asks about protein intake, nutrition advice, or dietary recommendations."
+            "Use this for all protein targets, macro recommendations, nutrition advice, and dietary recommendations."
         ),
         "system_prompt": (
             "You are a nutrition specialist focused on evidence-based recommendations. \n\n"
@@ -189,6 +190,8 @@ AGENT_REGISTRY: dict[str, dict] = {
         "tools": [
             "search_memory",
             "manage_memory",
+            "get_tennis_workouts",
+            "get_workout_data",
         ],
     },
 }

--- a/whoopdata/agent/tools.py
+++ b/whoopdata/agent/tools.py
@@ -5,7 +5,7 @@ import json
 from langchain_core.tools import tool
 from langchain_experimental.tools import PythonREPLTool
 from . import settings
-from .memory_tools import search_memory
+from .memory_tools import search_memory, manage_memory
 
 
 # WHOOP Recovery Tools
@@ -1143,6 +1143,7 @@ def _build_tools_by_name(tools_list: list) -> dict[str, object]:
 AVAILABLE_TOOLS = [
     # WHOOP Recovery Tools
     get_recovery_data_tool,
+    get_top_recoveries_tool,
     get_recovery_trends_tool,
     # WHOOP Sleep Tools
     get_sleep_data_tool,
@@ -1182,3 +1183,4 @@ AVAILABLE_TOOLS = [
 # Populate name-based lookup
 TOOLS_BY_NAME = _build_tools_by_name(AVAILABLE_TOOLS)
 TOOLS_BY_NAME["search_memory"] = search_memory
+TOOLS_BY_NAME["manage_memory"] = manage_memory


### PR DESCRIPTION
## Summary
Implements core agent architecture fixes and routing refinements:
- register missing `manage_memory` in `TOOLS_BY_NAME`
- expose `get_top_recoveries` to health_data
- remove direct supervisor protein tool route
- tighten routing boundaries in registry + supervisor prompt
- add workout-context tools to biomechanics
- update agent README routing/tooling documentation

## Linear
- AGE-57
- AGE-58
- AGE-59
- AGE-60
- AGE-61

Co-Authored-By: Oz <oz-agent@warp.dev>
