### PR TITLE
feat(biomechanics): phase-strip groundstroke analysis (v3.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the WHOOP Data Platform will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.10.0] - 2026-06-03
+
+### Added
+- Phase-strip frame selection for tennis groundstrokes: `segment_stroke_phases()` carves each detected forehand/backhand into an ordered strip (preparation -> backswing -> forward swing -> contact -> follow-through). The best and worst rep are sent to the LLM as ~8-12 phase-labelled annotated frames instead of a single peak frame.
+- New `whoopdata/agent/reference_angles.py` -- single source of truth for phase-keyed reference *bands* (not point targets), consumed by both the overlay and the prompt. Forehand bands are literature-anchored (contact elbow 100-130 deg, grip-dependent); backhand bands are wider/low-confidence.
+- Kinetic-chain timing (`_kinetic_chain_order`): orders hip -> shoulder -> elbow -> wrist by peak-speed time and flags arm-led sequencing. Measurable from 2D even where rotation magnitude is not.
+- Soft warnings + orientation gate: low pose-detection ratio, no strokes detected (evenly-spaced fallback strip), single-rep, and a warning when the racket arm is on the occluded far side. Warnings are shown to the user and injected into the prompt so coaching hedges its confidence.
+- `/videotips` Telegram command and a once-per-chat first-video hint with filming guidance (10-30s, side-on with the racket arm to camera, full body, 60 fps, caption the shot).
+- New tests in `tests/test_pose_analysis.py` covering phase segmentation, kinetic-chain ordering, band lookups/deviation, aggregation strips, orientation, and phase-aware prompt text.
+
+### Changed
+- The video pipeline now sends an ordered phase strip per selected rep rather than a single peak frame; `AggregatedMetrics` gains `key_phase_strips`, `pose_detection_ratio`, and `warnings`, and `RepMetrics` gains `phase_frames` and kinetic-chain fields.
+- Reference angles consolidated: removed the duplicated `telegram_bot._REFERENCE_ANGLES`/`_get_reference_angles` in favour of `reference_angles.get_phase_reference`. Overlay deviation is now computed against acceptable bands (zero inside the band).
+- Biomechanics prompt (`biomechanics_sub_agent.md`) gains forehand/backhand phase sections, instructs the model to reason across the phase strip, treats the contact frame as approximate (~5 ms contact vs 30 fps), and forbids presenting rotation (e.g. shoulder-hip separation) as a measured fault.
+
+### Notes
+- Reference angle bands are **provisional and flagged for SME review**: forehand is anchored to the literature; backhand joint angles are sparsely quantified and graded on fewer joints at lower confidence.
+
 ## [3.9.0] - 2026-04-12
 
 ### Added

--- a/data/prompts/agents/biomechanics_sub_agent.md
+++ b/data/prompts/agents/biomechanics_sub_agent.md
@@ -68,6 +68,46 @@ Kinetic chain: Ground reaction forces → Legs (51-55% of total kinetic energy) 
 - Foot-up: back foot moves to front foot before leg drive; higher front knee extension velocity
 - Foot-back: back foot stays behind; more stable base, less leg drive contribution
 
+### Tennis Forehand (Groundstroke)
+
+Phases (as labelled in the frames): Preparation → Backswing (loading) → Forward swing → Contact → Follow-through.
+
+Kinetic chain: ground → legs → hip/trunk rotation → shoulder → elbow → wrist → racket. The frames include a measured chain order; comment if it is "out of sequence (arm-led)".
+
+These are **measurable, in-plane reference bands** (camera-side, side-on view). They are
+evidence-informed but provisional — treat them as guides, not absolutes. Joint angle =
+interior angle (180° = straight limb).
+
+**Backswing (loading)**
+- Elbow flexion: 90-140°
+- Knee flexion (front leg): 120-155° (meaningful bend = good loading)
+- Shoulder elevation: 30-80°
+
+**Contact** (frame is approximate — see note)
+- Elbow flexion: 100-130° (grip-dependent: ~130° Eastern, ~100° Western — both fine)
+- Knee flexion: 140-175° (leg drive extending into the shot)
+- Shoulder elevation: 80-130°
+
+**Follow-through**
+- Elbow flexion: 40-100° (arm folds across the body)
+- Knee flexion: 150-180°
+- Shoulder elevation: 90-140°
+
+**Common faults (in-plane, measurable)**
+- Insufficient knee bend at loading → arm-dominant stroke, less power from the legs
+- Elbow over-bent or over-straight at contact vs the 100-130° band → timing/spacing issue
+- Truncated follow-through (arm stops early) → deceleration stress, lost control
+
+### Tennis Backhand
+
+Same phase labels as the forehand. **Lower confidence** — groundstroke backhand joint angles
+are sparsely quantified in the literature, and one- vs two-handed cannot be told from pose
+alone, so bands are wide. Grade mainly knee loading and follow-through completeness.
+
+- Backswing: elbow 70-140°, knee flexion 120-155°
+- Contact: elbow 120-175° (one-hander straighter), knee 140-175°
+- Follow-through: elbow 90-175°, knee 150-180°
+
 ### Barbell Back Squat
 
 **Starting/Ending Position**
@@ -183,6 +223,9 @@ I also noticed 2 other things -- ask if you'd like me to go deeper on: knee driv
 - Prioritise injury prevention over performance optimisation
 - Always include at least one positive observation -- reinforcement matters
 - When overlays are present, reference the specific markers/lines visible
+- For tennis groundstrokes you receive an **ordered phase strip** (preparation → backswing → forward swing → contact → follow-through) for the best and worst rep. Reason across the phases — comment on transitions (e.g. late/early contact, insufficient loading, truncated follow-through), not just a single frame.
+- **Treat the contact frame as approximate.** Phone video is typically 30 fps and ball contact lasts ~5 ms, so the captured "contact" frame is near-impact, not impact. Don't over-interpret the exact contact angle; weight the loading and follow-through phases and the kinetic-chain ordering more heavily.
+- **Do not cite rotation as measured.** Shoulder-hip separation and shoulder internal/external rotation cannot be measured from a single 2D side-on view. You may mention them qualitatively, but never quote a measured rotation angle or flag a rotation fault as if it were measured.
 - For text follow-ups (no frames), search memory first for the most recent analysis of that activity
 - Do not diagnose injuries or prescribe rehabilitation protocols
 - If concerning movement patterns suggest injury risk, recommend professional assessment (physio/sports medicine)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "3.9.0"
+version = "3.10.0"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_pose_analysis.py
+++ b/tests/test_pose_analysis.py
@@ -204,33 +204,296 @@ def test_preprocess_frames_is_still_passthrough():
     assert _preprocess_frames(frames) is frames
 
 
-def test_get_reference_angles_tennis_serve():
-    """Serve should return serve-specific reference angles."""
-    from whoopdata.telegram_bot import _get_reference_angles
-
-    refs = _get_reference_angles("tennis serve")
-    assert refs.get("right_elbow_flexion") == 30.0
+# ---------------------------------------------------------------------------
+# reference_angles.get_phase_reference (phase-keyed bands, single source)
+# ---------------------------------------------------------------------------
 
 
-def test_get_reference_angles_forehand():
-    """Forehand should return forehand-specific reference angles."""
-    from whoopdata.telegram_bot import _get_reference_angles
+def test_get_phase_reference_forehand_contact_band():
+    """Forehand contact returns the grip-spanning elbow band, mirrored L/R."""
+    from whoopdata.agent.reference_angles import get_phase_reference
 
-    refs = _get_reference_angles("analyse my forehand")
-    assert refs.get("right_elbow_flexion") == 90.0
-
-
-def test_get_reference_angles_squat():
-    """Squat activity should return knee reference angles."""
-    from whoopdata.telegram_bot import _get_reference_angles
-
-    refs = _get_reference_angles("squat")
-    assert refs.get("right_knee_flexion") == 100.0
+    refs = get_phase_reference("analyse my forehand", "contact")
+    assert refs["right_elbow_flexion"] == (100.0, 130.0)
+    assert refs["left_elbow_flexion"] == (100.0, 130.0)
 
 
-def test_get_reference_angles_unknown():
-    """Unknown activity should return empty dict."""
-    from whoopdata.telegram_bot import _get_reference_angles
+def test_get_phase_reference_unknown_phase_falls_back_to_contact():
+    """An unknown phase label falls back to the contact bands."""
+    from whoopdata.agent.reference_angles import get_phase_reference
 
-    refs = _get_reference_angles("cricket")
-    assert refs == {}
+    refs = get_phase_reference("forehand", "nonsense")
+    assert refs["right_elbow_flexion"] == (100.0, 130.0)
+
+
+def test_get_phase_reference_non_groundstroke_empty():
+    """Non-groundstroke activities (or empty) are not graded here."""
+    from whoopdata.agent.reference_angles import get_phase_reference
+
+    assert get_phase_reference("squat", "contact") == {}
+    assert get_phase_reference("", "contact") == {}
+
+
+def test_get_phase_reference_backhand_wider_band():
+    """Backhand bands are wider (lower confidence) than forehand."""
+    from whoopdata.agent.reference_angles import get_phase_reference
+
+    refs = get_phase_reference("backhand", "contact")
+    assert refs["right_elbow_flexion"] == (120.0, 175.0)
+
+
+def test_telegram_no_longer_defines_reference_angles():
+    """Reference angles now live only in reference_angles (no duplication)."""
+    import whoopdata.telegram_bot as tb
+
+    assert not hasattr(tb, "_REFERENCE_ANGLES")
+    assert not hasattr(tb, "_get_reference_angles")
+
+
+# ---------------------------------------------------------------------------
+# _target_and_deviation / band-aware deviation colour (pose_overlay)
+# ---------------------------------------------------------------------------
+
+
+def test_target_and_deviation_inside_band():
+    """A value inside the band has zero deviation; target is the value itself."""
+    from whoopdata.agent.pose_overlay import _target_and_deviation
+
+    target, dev = _target_and_deviation(118.0, (100.0, 130.0))
+    assert target == 118.0
+    assert dev == 0.0
+
+
+def test_target_and_deviation_outside_band():
+    """Outside the band, deviation is the distance to the nearest edge."""
+    from whoopdata.agent.pose_overlay import _target_and_deviation
+
+    assert _target_and_deviation(140.0, (100.0, 130.0)) == (130.0, 10.0)
+    assert _target_and_deviation(80.0, (100.0, 130.0)) == (100.0, 20.0)
+
+
+def test_target_and_deviation_scalar_and_none():
+    """Scalar references still work; None inputs yield (None, 0.0)."""
+    from whoopdata.agent.pose_overlay import _target_and_deviation
+
+    assert _target_and_deviation(45.0, 30.0) == (30.0, 15.0)
+    assert _target_and_deviation(None, (1.0, 2.0)) == (None, 0.0)
+    assert _target_and_deviation(50.0, None) == (None, 0.0)
+
+
+def test_deviation_colour_band():
+    """Band-aware colour: inside is white, far outside is red."""
+    assert _deviation_colour(115.0, (100.0, 130.0)) == (180, 180, 180)
+    assert _deviation_colour(170.0, (100.0, 130.0)) == (0, 0, 240)
+
+
+# ---------------------------------------------------------------------------
+# segment_stroke_phases
+# ---------------------------------------------------------------------------
+
+
+def _triangular_speeds(n: int, peak: int) -> list[float]:
+    return [max(0.0, 10.0 - abs(peak - i)) for i in range(n)]
+
+
+def test_segment_phases_contact_is_peak_and_ordered():
+    """Contact equals the peak frame; indices are strictly increasing."""
+    from whoopdata.agent.pose_analysis import segment_stroke_phases
+
+    n = 21
+    ev = EventWindow(0, n - 1, "forehand", 12)
+    phases = segment_stroke_phases(ev, _triangular_speeds(n, 12), [float(i) for i in range(n)])
+    labels = [p for p, _ in phases]
+    idxs = [i for _, i in phases]
+    assert "contact" in labels
+    assert dict(phases)["contact"] == 12
+    assert idxs == sorted(idxs)
+    assert len(set(idxs)) == len(idxs)
+    assert 4 <= len(phases) <= 6
+
+
+def test_segment_phases_backswing_is_x_extreme():
+    """Backswing is the wrist horizontal extreme before contact."""
+    from whoopdata.agent.pose_analysis import segment_stroke_phases
+
+    n = 21
+    wrist_xs = [0.0] * n
+    wrist_xs[4] = 100.0  # clear pre-contact extreme
+    ev = EventWindow(0, n - 1, "forehand", 12)
+    phases = dict(segment_stroke_phases(ev, _triangular_speeds(n, 12), wrist_xs))
+    assert phases["backswing"] == 4
+
+
+def test_segment_phases_missing_xs_fallback():
+    """Missing wrist positions still yield ordered, in-window phases."""
+    from whoopdata.agent.pose_analysis import segment_stroke_phases
+
+    n = 11
+    ev = EventWindow(0, n - 1, "forehand", 5)
+    phases = segment_stroke_phases(ev, [None] * n, [None] * n)
+    idxs = [i for _, i in phases]
+    assert 4 <= len(phases) <= 6
+    assert all(0 <= i <= n - 1 for i in idxs)
+    assert idxs == sorted(idxs)
+
+
+def test_segment_phases_tiny_window():
+    """A tiny window degrades gracefully (ordered, unique, in-window)."""
+    from whoopdata.agent.pose_analysis import segment_stroke_phases
+
+    ev = EventWindow(0, 2, "forehand", 1)
+    phases = segment_stroke_phases(ev, [1.0, 2.0, 1.0], [0.0, 1.0, 2.0])
+    idxs = [i for _, i in phases]
+    assert all(0 <= i <= 2 for i in idxs)
+    assert idxs == sorted(idxs)
+    assert len(set(idxs)) == len(idxs)
+
+
+# ---------------------------------------------------------------------------
+# _kinetic_chain_order
+# ---------------------------------------------------------------------------
+
+
+def _spike(peak: int, n: int = 10) -> list[float]:
+    return [1.0 if i == peak else 0.0 for i in range(n)]
+
+
+def test_kinetic_chain_in_sequence():
+    """Proximal->distal peak timing is in sequence."""
+    from whoopdata.agent.pose_analysis import _kinetic_chain_order
+
+    speeds = {"hip": _spike(1), "shoulder": _spike(3), "elbow": _spike(5), "wrist": _spike(7)}
+    order, ok = _kinetic_chain_order(speeds, 0, 9)
+    assert order == ["hip", "shoulder", "elbow", "wrist"]
+    assert ok is True
+
+
+def test_kinetic_chain_out_of_sequence():
+    """Wrist-first (arm-led) timing is flagged out of sequence."""
+    from whoopdata.agent.pose_analysis import _kinetic_chain_order
+
+    speeds = {"hip": _spike(7), "shoulder": _spike(5), "elbow": _spike(3), "wrist": _spike(1)}
+    _order, ok = _kinetic_chain_order(speeds, 0, 9)
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Aggregation: phase strips + flattened key frames
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_builds_best_and_worst_phase_strips():
+    """Three reps with distinct contact angles yield best + worst strips."""
+    from whoopdata.agent.pose_analysis import FrameAngles, PoseAnalyser
+
+    n = 33
+
+    def fa(i: int) -> FrameAngles:
+        elbow = 110.0
+        if i == 15:
+            elbow = 112.0
+        elif i == 27:
+            elbow = 140.0
+        return FrameAngles(i, {"right_elbow_flexion": elbow, "right_knee_flexion": 150.0})
+
+    all_angles = [fa(i) for i in range(n)]
+    wrist_speeds = [1.0] * n
+    wrist_xs = [float(i) for i in range(n)]
+    speed_series = {k: [0.0] * n for k in ("hip", "shoulder", "elbow", "wrist")}
+    events = [
+        EventWindow(0, 9, "forehand", 5),
+        EventWindow(11, 20, "forehand", 15),
+        EventWindow(22, 32, "forehand", 27),
+    ]
+
+    analyser = PoseAnalyser(activity="forehand")
+    per_rep = analyser._compute_per_rep_metrics(
+        events, all_angles, wrist_speeds, wrist_xs, speed_series
+    )
+    metrics = analyser._aggregate_metrics(per_rep)
+
+    assert len(metrics.key_phase_strips) == 2
+    assert {s.role for s in metrics.key_phase_strips} == {"best", "worst"}
+    assert metrics.key_frame_indices == sorted(set(metrics.key_frame_indices))
+    assert all(0 <= i < n for i in metrics.key_frame_indices)
+    assert len(metrics.key_frame_indices) <= 12
+
+
+# ---------------------------------------------------------------------------
+# Orientation gate + warnings + phase-aware prompt text
+# ---------------------------------------------------------------------------
+
+
+class _FakeLandmark:
+    def __init__(self, visibility: float) -> None:
+        self.visibility = visibility
+        self.x = 0.0
+        self.y = 0.0
+
+
+def _fake_pose(right_vis: float, left_vis: float) -> list:
+    from whoopdata.agent.pose_analysis import Landmarks
+
+    lms = [_FakeLandmark(0.9) for _ in range(33)]
+    for i in (Landmarks.RIGHT_SHOULDER, Landmarks.RIGHT_ELBOW, Landmarks.RIGHT_WRIST):
+        lms[i] = _FakeLandmark(right_vis)
+    for i in (Landmarks.LEFT_SHOULDER, Landmarks.LEFT_ELBOW, Landmarks.LEFT_WRIST):
+        lms[i] = _FakeLandmark(left_vis)
+    return lms
+
+
+def test_orientation_warning_when_racket_arm_occluded():
+    """Right (racket) arm hidden -> orientation warning."""
+    from whoopdata.agent.pose_analysis import _orientation_warning
+
+    assert _orientation_warning([_fake_pose(0.2, 0.9)]) is not None
+
+
+def test_orientation_warning_none_when_visible():
+    """Both arms visible -> no orientation warning."""
+    from whoopdata.agent.pose_analysis import _orientation_warning
+
+    assert _orientation_warning([_fake_pose(0.9, 0.9)]) is None
+
+
+def test_format_for_prompt_phase_block():
+    """Phase strips render grouped phase lines with target bands + chain."""
+    from whoopdata.agent.pose_analysis import KeyPhaseStrip
+
+    rep = RepMetrics(
+        rep_number=1,
+        event=EventWindow(0, 20, "forehand", 10),
+        key_angles={
+            "backswing": {"right_elbow_flexion": 120.0, "right_knee_flexion": 140.0},
+            "contact": {"right_elbow_flexion": 118.0},
+        },
+        phase_frames=[("backswing", 4), ("contact", 10)],
+        chain_order=["hip", "shoulder", "elbow", "wrist"],
+        chain_ok=True,
+    )
+    metrics = AggregatedMetrics(
+        activity="forehand",
+        num_reps=1,
+        per_rep=[rep],
+        key_phase_strips=[
+            KeyPhaseStrip(
+                rep_number=1,
+                role="best",
+                event_type="forehand",
+                phases=[("backswing", 4), ("contact", 10)],
+            )
+        ],
+    )
+    text = metrics.format_for_prompt()
+    assert "forehand -- best rep" in text
+    assert "contact:" in text
+    assert "(target 100-130)" in text
+    assert "kinetic chain" in text
+
+
+def test_format_for_prompt_includes_warnings():
+    """Soft warnings surface as NOTE lines so the model can hedge."""
+    metrics = AggregatedMetrics(
+        activity="forehand", num_reps=1, per_rep=[], warnings=["low tracking"]
+    )
+    assert "NOTE: low tracking" in metrics.format_for_prompt()

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "3.9.0"
+__version__ = "3.10.0"

--- a/whoopdata/agent/pose_analysis.py
+++ b/whoopdata/agent/pose_analysis.py
@@ -22,6 +22,11 @@ from typing import Protocol
 import cv2
 import numpy as np
 
+from whoopdata.agent.reference_angles import (
+    GROUNDSTROKE_ACTIVITIES,
+    get_phase_reference,
+)
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -38,6 +43,15 @@ _MODEL_FILE = "pose_landmarker_lite.task"
 VISIBILITY_THRESHOLD = 0.5
 MAX_DENSE_FRAMES = 600
 MAX_VIDEO_DURATION_SECONDS = 60
+
+# Phase-strip and robustness limits.
+MAX_PHASES_PER_REP = 6  # cap phase frames sent to the LLM per rep
+MAX_STRIP_REPS = 2  # only the best + worst rep get a phase strip
+LOW_POSE_DETECTION_RATIO = 0.5  # warn below this fraction of frames with a pose
+MIN_REPS_FOR_CONFIDENCE = 2  # below this, cross-rep comparison is unreliable
+
+# Canonical position key used for cross-rep comparison and best/worst selection.
+CONTACT_POSITION = "contact"
 
 
 class Landmarks:
@@ -170,6 +184,172 @@ def find_peaks(
     return peaks
 
 
+def _argmin_in_range(values: list[float | None], lo: int, hi: int) -> int | None:
+    """Index of the smallest non-None value in ``values[lo:hi+1]`` (or None)."""
+    best_idx: int | None = None
+    best_val = float("inf")
+    for i in range(max(0, lo), min(len(values) - 1, hi) + 1):
+        v = values[i]
+        if v is None:
+            continue
+        if v < best_val:
+            best_val = v
+            best_idx = i
+    return best_idx
+
+
+def segment_stroke_phases(
+    event: "EventWindow",
+    wrist_speeds: list[float | None],
+    wrist_xs: list[float | None],
+    *,
+    handedness: str = "right",
+) -> list[tuple[str, int]]:
+    """Derive ordered ``(phase_label, frame_index)`` tuples for one groundstroke.
+
+    A groundstroke arcs preparation -> backswing -> forward swing -> contact ->
+    follow-through. Contact is the wrist-speed peak (``event.peak_frame``);
+    backswing is the wrist's horizontal extreme before contact; follow-through
+    is the post-contact deceleration point. All phases are read off the
+    pre-computed speed/position arrays -- nothing is recomputed here.
+
+    Args:
+        event: The detected stroke window (start/end/peak frames).
+        wrist_speeds: Per-frame wrist displacement magnitude.
+        wrist_xs: Per-frame wrist horizontal pixel position (``None`` if hidden).
+        handedness: Reserved; the backswing heuristic is handedness-agnostic
+            (it keys off distance from the contact-frame x position).
+
+    Returns:
+        4-6 ordered ``(phase_label, frame_index)`` tuples with strictly
+        increasing, in-window indices. Falls back to evenly spaced frames when
+        the wrist signal is missing.
+
+    Example:
+        >>> ev = EventWindow(0, 20, "forehand", 12)
+        >>> phases = segment_stroke_phases(ev, [0.0]*21, [float(i) for i in range(21)])
+        >>> [p for p, _ in phases][0], phases[-1][1] <= 20
+        ('preparation', True)
+    """
+    start, end, contact = event.start_frame, event.end_frame, event.peak_frame
+    contact = max(start, min(end, contact))
+
+    def _spaced() -> list[tuple[str, int]]:
+        idxs = np.linspace(start, end, 5, dtype=int).tolist()
+        labels = ["preparation", "backswing", "forward_swing", "contact", "follow_through"]
+        seen: set[int] = set()
+        out: list[tuple[str, int]] = []
+        for label, idx in zip(labels, idxs):
+            if idx not in seen:
+                out.append((label, int(idx)))
+                seen.add(idx)
+        return out
+
+    x_at_contact = wrist_xs[contact] if 0 <= contact < len(wrist_xs) else None
+    xs_pre: list[tuple[int, float]] = []
+    for i in range(start, contact):
+        if 0 <= i < len(wrist_xs):
+            xv = wrist_xs[i]
+            if xv is not None:
+                xs_pre.append((i, xv))
+    if x_at_contact is None and xs_pre:
+        x_at_contact = float(np.median([x for _, x in xs_pre]))
+
+    # Backswing: wrist horizontal extreme (farthest from the contact x) before contact.
+    if xs_pre and x_at_contact is not None:
+        xc = x_at_contact  # bound here so the closure sees a non-None float
+        backswing = max(xs_pre, key=lambda pair: abs(pair[1] - xc))[0]
+    else:
+        backswing = start + max(1, (contact - start) // 4)
+    backswing = max(start, min(contact - 1, backswing)) if contact > start else start
+
+    # Preparation: velocity minimum (settle) before the backswing, else midpoint.
+    prep = _argmin_in_range(wrist_speeds, start, backswing)
+    if prep is None or prep >= backswing:
+        prep = start + (backswing - start) // 2
+
+    # Forward swing: midpoint of backswing -> contact (rising velocity region).
+    forward = backswing + (contact - backswing) // 2
+
+    # Follow-through: first post-contact frame where speed drops below half of
+    # the contact speed, else the midpoint of contact -> end.
+    follow = contact + (end - contact) // 2
+    speed_at_contact = wrist_speeds[contact] if 0 <= contact < len(wrist_speeds) else None
+    if speed_at_contact:
+        for i in range(contact + 1, min(len(wrist_speeds), end + 1)):
+            s = wrist_speeds[i]
+            if s is not None and s < 0.5 * speed_at_contact:
+                follow = i
+                break
+
+    ordered = [
+        ("preparation", prep),
+        ("backswing", backswing),
+        ("forward_swing", forward),
+        ("contact", contact),
+        ("follow_through", follow),
+    ]
+
+    # Enforce strictly increasing, de-duplicated, in-window indices.
+    result: list[tuple[str, int]] = []
+    last = -1
+    for label, idx in ordered:
+        idx = int(max(start, min(end, idx)))
+        if idx <= last:
+            continue
+        result.append((label, idx))
+        last = idx
+
+    if len(result) < 4:
+        return _spaced()
+    return result[:MAX_PHASES_PER_REP]
+
+
+def _kinetic_chain_order(
+    speed_series: dict[str, list[float | None]],
+    lo: int,
+    hi: int,
+) -> tuple[list[str], bool]:
+    """Order proximal->distal joints by when each reaches peak speed.
+
+    A sound groundstroke sequences hip -> shoulder -> elbow -> wrist (the
+    kinetic chain). We can measure this *timing* from 2D even though we cannot
+    measure rotation magnitude. ``chain_ok`` is True when the observed peak
+    times are non-decreasing in the ideal proximal->distal order.
+
+    Args:
+        speed_series: Mapping of joint name to its per-frame speed series.
+        lo: Window start frame (inclusive).
+        hi: Window end frame (inclusive).
+
+    Returns:
+        ``(order, chain_ok)`` where order is joint names sorted by peak time.
+    """
+    ideal = ["hip", "shoulder", "elbow", "wrist"]
+    peak_times: dict[str, int] = {}
+    for joint in ideal:
+        series = speed_series.get(joint, [])
+        best_t, best_v = None, float("-inf")
+        for i in range(max(0, lo), min(len(series) - 1, hi) + 1):
+            v = series[i]
+            if v is not None and v > best_v:
+                best_v, best_t = v, i
+        if best_t is not None:
+            peak_times[joint] = best_t
+
+    if len(peak_times) < 2:
+        return (list(peak_times.keys()), True)
+
+    order = sorted(peak_times, key=lambda j: peak_times[j])
+    ideal_present = [j for j in ideal if j in peak_times]
+    times_in_ideal_order = [peak_times[j] for j in ideal_present]
+    chain_ok = all(
+        times_in_ideal_order[i] <= times_in_ideal_order[i + 1] + 1
+        for i in range(len(times_in_ideal_order) - 1)
+    )
+    return (order, chain_ok)
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -213,14 +393,40 @@ class RepMetrics:
     Attributes:
         rep_number: 1-based rep index.
         event: The detected event window.
-        key_angles: Angles at key positions (e.g. ``{"trophy": {...}, "contact": {...}}``).
+        key_angles: Angles keyed by phase label (e.g.
+            ``{"backswing": {...}, "contact": {...}}``). Non-groundstroke events
+            use a single ``"contact"`` position.
         peak_wrist_speed: Maximum wrist displacement between frames (pixels/frame).
+        phase_frames: Ordered ``(phase_label, frame_index)`` for the rep
+            (the phase strip). Single entry for non-groundstroke events.
+        chain_order: Joint names ordered by peak-speed time (proximal->distal).
+        chain_ok: Whether the kinetic chain sequenced proximal->distal.
     """
 
     rep_number: int
     event: EventWindow
     key_angles: dict[str, dict[str, float | None]]
     peak_wrist_speed: float | None = None
+    phase_frames: list[tuple[str, int]] = field(default_factory=list)
+    chain_order: list[str] = field(default_factory=list)
+    chain_ok: bool = True
+
+
+@dataclass
+class KeyPhaseStrip:
+    """A phase strip for one selected rep, sent to the LLM and annotated.
+
+    Attributes:
+        rep_number: 1-based rep index.
+        role: ``"best"`` (most representative) or ``"worst"`` (largest deviation).
+        event_type: Stroke label (e.g. ``"forehand"``).
+        phases: Ordered ``(phase_label, frame_index)`` tuples.
+    """
+
+    rep_number: int
+    role: str
+    event_type: str
+    phases: list[tuple[str, int]]
 
 
 @dataclass
@@ -248,6 +454,9 @@ class AggregatedMetrics:
     best_rep_idx: int = 0
     fatigue_drift: dict[str, float] = field(default_factory=dict)
     key_frame_indices: list[int] = field(default_factory=list)
+    key_phase_strips: list[KeyPhaseStrip] = field(default_factory=list)
+    pose_detection_ratio: float = 1.0
+    warnings: list[str] = field(default_factory=list)
 
     def format_for_prompt(self, reference_angles: dict[str, float | None] | None = None) -> str:
         """Format metrics as a structured text block for the biomechanics agent prompt.
@@ -267,6 +476,55 @@ class AggregatedMetrics:
             'Across 3 serves:\\n  ...'
         """
         lines = [f"Across {self.num_reps} {self.activity} rep(s):"]
+
+        # Soft warnings first so the model can hedge its confidence.
+        for warning in self.warnings:
+            lines.append(f"NOTE: {warning}")
+
+        # Phase-strip block (groundstrokes): per selected rep, the angles at
+        # each phase with the evidence-based target band, plus the kinetic chain.
+        if self.key_phase_strips:
+            rep_by_number = {rep.rep_number: rep for rep in self.per_rep}
+            for strip in self.key_phase_strips:
+                rep = rep_by_number.get(strip.rep_number)
+                lines.append(f"{strip.event_type} -- {strip.role} rep (rep {strip.rep_number}):")
+                for phase_label, _frame_idx in strip.phases:
+                    angles = rep.key_angles.get(phase_label, {}) if rep else {}
+                    refs = get_phase_reference(strip.event_type, phase_label)
+                    parts: list[str] = []
+                    for joint in (
+                        "right_elbow_flexion",
+                        "left_elbow_flexion",
+                        "right_knee_flexion",
+                        "left_knee_flexion",
+                        "right_shoulder_elevation",
+                    ):
+                        val = angles.get(joint)
+                        if val is None:
+                            continue
+                        band = refs.get(joint)
+                        short = joint.replace("_flexion", "").replace("_", " ")
+                        if band:
+                            parts.append(
+                                f"{short} {val:.0f} deg (target {band[0]:.0f}-{band[1]:.0f})"
+                            )
+                        else:
+                            parts.append(f"{short} {val:.0f} deg")
+                        if len(parts) >= 3:
+                            break
+                    if parts:
+                        lines.append(f"  {phase_label}: " + ", ".join(parts))
+                if rep and rep.chain_order:
+                    chain = " -> ".join(rep.chain_order)
+                    status = "in sequence" if rep.chain_ok else "out of sequence (arm-led)"
+                    lines.append(f"  kinetic chain: {chain} ({status})")
+            lines.append(
+                "Note: contact frame is approximate at typical phone frame rates; "
+                "rotation (shoulder-hip separation) is not measured from a single 2D view."
+            )
+            return "\n".join(lines)
+
+        # Legacy / non-groundstroke summary: per-joint means across reps.
         for joint_name, mean_vals in self.mean_angles.items():
             for position, mean_val in mean_vals.items():
                 std_val = self.std_angles.get(joint_name, {}).get(position, 0.0)
@@ -541,9 +799,7 @@ def _ensure_model() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _get_point(
-    landmarks: list, idx: int, width: int, height: int
-) -> tuple[float, float] | None:
+def _get_point(landmarks: list, idx: int, width: int, height: int) -> tuple[float, float] | None:
     """Extract pixel coordinates for a landmark if visibility is sufficient.
 
     Args:
@@ -561,9 +817,7 @@ def _get_point(
     return (lm.x * width, lm.y * height)
 
 
-def _compute_frame_angles(
-    landmarks: list, width: int, height: int
-) -> dict[str, float | None]:
+def _compute_frame_angles(landmarks: list, width: int, height: int) -> dict[str, float | None]:
     """Compute all configured joint angles for a single frame.
 
     Args:
@@ -614,6 +868,41 @@ def _compute_speed(
     return float(np.sqrt((curr[0] - prev[0]) ** 2 + (curr[1] - prev[1]) ** 2))
 
 
+def _orientation_warning(all_landmarks: list[list | None]) -> str | None:
+    """Warn if the tracked (right) arm appears to be the occluded far side.
+
+    Single-camera pose is far less accurate for the occluded limb, so we ask
+    the user to film with their racket arm toward the camera. Heuristic:
+    compare mean landmark visibility of the right vs left arm over detected
+    frames.
+
+    Args:
+        all_landmarks: Per-frame landmark lists (``None`` where no pose found).
+
+    Returns:
+        A user-facing warning string, or ``None`` if orientation looks fine.
+    """
+    right_idx = [Landmarks.RIGHT_SHOULDER, Landmarks.RIGHT_ELBOW, Landmarks.RIGHT_WRIST]
+    left_idx = [Landmarks.LEFT_SHOULDER, Landmarks.LEFT_ELBOW, Landmarks.LEFT_WRIST]
+    right_vis: list[float] = []
+    left_vis: list[float] = []
+    for lms in all_landmarks:
+        if lms is None:
+            continue
+        right_vis.extend(lms[i].visibility for i in right_idx)
+        left_vis.extend(lms[i].visibility for i in left_idx)
+    if not right_vis or not left_vis:
+        return None
+    right_mean = float(np.mean(right_vis))
+    left_mean = float(np.mean(left_vis))
+    if right_mean < 0.4 and (left_mean - right_mean) > 0.2:
+        return (
+            "Your right (racket) arm looks partly hidden from the camera. For accurate "
+            "angles, film side-on with your hitting arm toward the camera."
+        )
+    return None
+
+
 class PoseAnalyser:
     """Analyse dense video frames for biomechanics metrics.
 
@@ -662,9 +951,16 @@ class PoseAnalyser:
         """
         # Check specific shot types first, then generic activity names
         priority_order = [
-            "forehand", "backhand", "volley", "serve", "swing",
-            "squat", "deadlift",
-            "tennis", "gym", "workout",
+            "forehand",
+            "backhand",
+            "volley",
+            "serve",
+            "swing",
+            "squat",
+            "deadlift",
+            "tennis",
+            "gym",
+            "workout",
         ]
         for keyword in priority_order:
             if keyword in caption:
@@ -710,6 +1006,9 @@ class PoseAnalyser:
         all_angles: list[FrameAngles] = []
         wrist_speeds: list[float | None] = []
         shoulder_speeds: list[float | None] = []
+        hip_speeds: list[float | None] = []
+        elbow_speeds: list[float | None] = []
+        wrist_xs: list[float | None] = []
         timestamp_ms = 0
         interval_ms = int(1000 / fps) if fps > 0 else 33
         prev_landmarks: list | None = None
@@ -730,44 +1029,89 @@ class PoseAnalyser:
                     all_angles.append(FrameAngles(frame_idx=i, angles=angles))
 
                     ws = _compute_speed(prev_landmarks, lms, Landmarks.RIGHT_WRIST, w, h)
-                    ss = _compute_speed(
-                        prev_landmarks, lms, Landmarks.RIGHT_SHOULDER, w, h
-                    )
+                    ss = _compute_speed(prev_landmarks, lms, Landmarks.RIGHT_SHOULDER, w, h)
+                    hs = _compute_speed(prev_landmarks, lms, Landmarks.RIGHT_HIP, w, h)
+                    es = _compute_speed(prev_landmarks, lms, Landmarks.RIGHT_ELBOW, w, h)
+                    wrist_point = _get_point(lms, Landmarks.RIGHT_WRIST, w, h)
                     wrist_speeds.append(ws)
                     shoulder_speeds.append(ss)
+                    hip_speeds.append(hs)
+                    elbow_speeds.append(es)
+                    wrist_xs.append(wrist_point[0] if wrist_point is not None else None)
                     prev_landmarks = lms
                 else:
                     all_landmarks.append(None)
                     all_angles.append(FrameAngles(frame_idx=i, angles={}))
                     wrist_speeds.append(None)
                     shoulder_speeds.append(None)
+                    hip_speeds.append(None)
+                    elbow_speeds.append(None)
+                    wrist_xs.append(None)
                     prev_landmarks = None
 
-        # Validate detection
+        # Validate detection and build soft warnings (still attempt analysis).
         detected_count = sum(1 for lm in all_landmarks if lm is not None)
+        total = max(len(frames), 1)
+        detection_ratio = detected_count / total
+        warnings: list[str] = []
         if detected_count == 0:
             logger.warning(
                 "No pose detected in %d frames -- check video content and model file",
                 len(frames),
             )
+            warnings.append(
+                "I couldn't track your body in this clip. Try better lighting, a "
+                "side-on angle, and keep your whole body in frame."
+            )
+        elif detection_ratio < LOW_POSE_DETECTION_RATIO:
+            warnings.append(
+                f"I could only track your body in about {detection_ratio * 100:.0f}% of "
+                "frames, so this read is rough. Side-on, full-body, good lighting helps."
+            )
+
+        # Orientation gate: the tracked arm (right) should face the camera.
+        orient_warning = _orientation_warning(all_landmarks)
+        if orient_warning:
+            warnings.append(orient_warning)
 
         # Detect events
         if self._detector:
-            events = self._detector.detect_events(
-                all_angles, wrist_speeds, shoulder_speeds, fps
-            )
+            events = self._detector.detect_events(all_angles, wrist_speeds, shoulder_speeds, fps)
         else:
             events = []
 
-        # Fallback: treat entire clip as one event
+        # Fallback: no distinct strokes -> treat the whole clip as one window and
+        # warn, instead of silently sending a single middle frame.
         if not events and len(frames) > 0:
             events = [
                 EventWindow(0, len(frames) - 1, self._activity or "unknown", len(frames) // 2)
             ]
+            if detected_count > 0:
+                warnings.append(
+                    "I couldn't clearly detect distinct strokes, so here's a general "
+                    "look across the clip. For sharper feedback, film 3-5 separate "
+                    "forehands or backhands."
+                )
+
+        speed_series: dict[str, list[float | None]] = {
+            "hip": hip_speeds,
+            "shoulder": shoulder_speeds,
+            "elbow": elbow_speeds,
+            "wrist": wrist_speeds,
+        }
 
         # Per-rep metrics and aggregation
-        per_rep = self._compute_per_rep_metrics(events, all_angles, wrist_speeds)
+        per_rep = self._compute_per_rep_metrics(
+            events, all_angles, wrist_speeds, wrist_xs, speed_series
+        )
+        if 0 < len(per_rep) < MIN_REPS_FOR_CONFIDENCE:
+            warnings.append(
+                "Only one stroke detected -- I can't compare consistency across reps yet. "
+                "Film a few more for trend feedback."
+            )
         metrics = self._aggregate_metrics(per_rep)
+        metrics.pose_detection_ratio = detection_ratio
+        metrics.warnings = warnings
 
         return AnalysisResult(
             all_landmarks=all_landmarks,
@@ -776,6 +1120,9 @@ class PoseAnalyser:
             metrics=metrics,
             wrist_speeds=wrist_speeds,
             shoulder_speeds=shoulder_speeds,
+            wrist_xs=wrist_xs,
+            pose_detection_ratio=detection_ratio,
+            warnings=warnings,
         )
 
     def _compute_per_rep_metrics(
@@ -783,37 +1130,64 @@ class PoseAnalyser:
         events: list[EventWindow],
         all_angles: list[FrameAngles],
         wrist_speeds: list[float | None],
+        wrist_xs: list[float | None],
+        speed_series: dict[str, list[float | None]],
     ) -> list[RepMetrics]:
         """Compute metrics for each detected repetition.
+
+        For groundstrokes, segments the rep into an ordered phase strip and
+        records angles per phase; other activities keep a single ``contact``
+        position. Also computes the kinetic-chain ordering per rep.
 
         Args:
             events: Detected event windows.
             all_angles: Per-frame joint angles.
             wrist_speeds: Per-frame wrist speeds.
+            wrist_xs: Per-frame wrist horizontal positions.
+            speed_series: Per-joint speed series for kinetic-chain timing.
 
         Returns:
             List of per-rep metrics.
         """
         reps: list[RepMetrics] = []
         for rep_num, event in enumerate(events, start=1):
-            # Find key angles at the peak frame
-            peak_idx = event.peak_frame
-            if 0 <= peak_idx < len(all_angles):
-                peak_angles = all_angles[peak_idx].angles
+            is_groundstroke = event.event_type in GROUNDSTROKE_ACTIVITIES
+            if is_groundstroke:
+                phase_frames = segment_stroke_phases(event, wrist_speeds, wrist_xs)
             else:
-                peak_angles = {}
+                peak = max(event.start_frame, min(event.end_frame, event.peak_frame))
+                phase_frames = [(CONTACT_POSITION, peak)]
 
-            # Peak wrist speed within event window
+            # Angles at each phase frame, keyed by phase label.
+            key_angles: dict[str, dict[str, float | None]] = {}
+            for label, idx in phase_frames:
+                key_angles[label] = all_angles[idx].angles if 0 <= idx < len(all_angles) else {}
+            # Guarantee a canonical contact position for cross-rep comparison.
+            if CONTACT_POSITION not in key_angles:
+                peak = max(event.start_frame, min(event.end_frame, event.peak_frame))
+                key_angles[CONTACT_POSITION] = (
+                    all_angles[peak].angles if 0 <= peak < len(all_angles) else {}
+                )
+
+            # Peak wrist speed within event window.
             event_wrist = wrist_speeds[event.start_frame : event.end_frame + 1]
             valid_speeds = [s for s in event_wrist if s is not None]
             peak_ws = max(valid_speeds) if valid_speeds else None
+
+            # Kinetic-chain timing across the lead-up to contact.
+            chain_order, chain_ok = _kinetic_chain_order(
+                speed_series, event.start_frame, event.peak_frame
+            )
 
             reps.append(
                 RepMetrics(
                     rep_number=rep_num,
                     event=event,
-                    key_angles={"peak": peak_angles},
+                    key_angles=key_angles,
                     peak_wrist_speed=peak_ws,
+                    phase_frames=phase_frames,
+                    chain_order=chain_order,
+                    chain_ok=chain_ok,
                 )
             )
         return reps
@@ -851,23 +1225,25 @@ class PoseAnalyser:
                 mean_angles[joint_name][position] = float(np.mean(vals))
                 std_angles[joint_name][position] = float(np.std(vals)) if len(vals) > 1 else 0.0
 
-        # Fatigue drift: first rep vs last rep
+        # Fatigue drift: first rep vs last rep, at the contact position.
         fatigue_drift: dict[str, float] = {}
         if len(per_rep) >= 2:
-            first = per_rep[0].key_angles.get("peak", {})
-            last = per_rep[-1].key_angles.get("peak", {})
+            first = per_rep[0].key_angles.get(CONTACT_POSITION, {})
+            last = per_rep[-1].key_angles.get(CONTACT_POSITION, {})
             for joint_name in first:
-                if first[joint_name] is not None and last.get(joint_name) is not None:
-                    fatigue_drift[f"{joint_name}_peak"] = last[joint_name] - first[joint_name]
+                first_val = first[joint_name]
+                last_val = last.get(joint_name)
+                if first_val is not None and last_val is not None:
+                    fatigue_drift[f"{joint_name}_{CONTACT_POSITION}"] = last_val - first_val
 
-        # Best and worst rep (by total deviation from mean)
+        # Best and worst rep (by total deviation from mean at contact).
         deviations = []
         for rep in per_rep:
             total_dev = 0.0
             count = 0
-            for joint_name, val in rep.key_angles.get("peak", {}).items():
+            for joint_name, val in rep.key_angles.get(CONTACT_POSITION, {}).items():
                 if val is not None and joint_name in mean_angles:
-                    mean_val = mean_angles[joint_name].get("peak", val)
+                    mean_val = mean_angles[joint_name].get(CONTACT_POSITION, val)
                     total_dev += abs(val - mean_val)
                     count += 1
             deviations.append(total_dev / max(count, 1))
@@ -875,12 +1251,36 @@ class PoseAnalyser:
         worst_idx = int(np.argmax(deviations)) if deviations else 0
         best_idx = int(np.argmin(deviations)) if deviations else 0
 
-        # Key frame indices
-        key_frames = []
-        if per_rep:
-            key_frames.append(per_rep[best_idx].event.peak_frame)
-            if worst_idx != best_idx:
-                key_frames.append(per_rep[worst_idx].event.peak_frame)
+        # Phase strips for the best + worst rep (these reach the LLM, annotated).
+        key_phase_strips: list[KeyPhaseStrip] = []
+        best_rep = per_rep[best_idx]
+        key_phase_strips.append(
+            KeyPhaseStrip(
+                rep_number=best_rep.rep_number,
+                role="best",
+                event_type=best_rep.event.event_type,
+                phases=best_rep.phase_frames,
+            )
+        )
+        if worst_idx != best_idx:
+            worst_rep = per_rep[worst_idx]
+            key_phase_strips.append(
+                KeyPhaseStrip(
+                    rep_number=worst_rep.rep_number,
+                    role="worst",
+                    event_type=worst_rep.event.event_type,
+                    phases=worst_rep.phase_frames,
+                )
+            )
+
+        # Flatten strip frames into key_frame_indices (archive / legacy paths).
+        key_frames: list[int] = []
+        seen: set[int] = set()
+        for strip in key_phase_strips:
+            for _label, idx in strip.phases:
+                if idx not in seen:
+                    seen.add(idx)
+                    key_frames.append(idx)
 
         return AggregatedMetrics(
             activity=activity,
@@ -892,6 +1292,7 @@ class PoseAnalyser:
             best_rep_idx=best_idx,
             fatigue_drift=fatigue_drift,
             key_frame_indices=key_frames,
+            key_phase_strips=key_phase_strips,
         )
 
 
@@ -906,6 +1307,9 @@ class AnalysisResult:
         metrics: Aggregated cross-rep metrics.
         wrist_speeds: Per-frame wrist displacement.
         shoulder_speeds: Per-frame shoulder displacement.
+        wrist_xs: Per-frame wrist horizontal pixel position.
+        pose_detection_ratio: Fraction of frames with a detected pose.
+        warnings: User-facing soft warnings (low tracking, no reps, orientation).
     """
 
     all_landmarks: list[list | None]
@@ -914,3 +1318,6 @@ class AnalysisResult:
     metrics: AggregatedMetrics
     wrist_speeds: list[float | None]
     shoulder_speeds: list[float | None]
+    wrist_xs: list[float | None] = field(default_factory=list)
+    pose_detection_ratio: float = 1.0
+    warnings: list[str] = field(default_factory=list)

--- a/whoopdata/agent/pose_overlay.py
+++ b/whoopdata/agent/pose_overlay.py
@@ -14,6 +14,7 @@ Colour scheme (following CourtCoach's proven UX):
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 
 import cv2
 import numpy as np
@@ -44,12 +45,51 @@ _GOOD_THRESHOLD = 15.0
 _WARN_THRESHOLD = 30.0
 
 
-def _deviation_colour(measured: float | None, reference: float | None) -> tuple[int, int, int]:
+def _target_and_deviation(
+    measured: float | None,
+    reference: float | tuple[float, float] | None,
+) -> tuple[float | None, float]:
+    """Resolve a target angle and the deviation of ``measured`` from it.
+
+    Accepts either a scalar reference (point target) or a ``(min, max)`` band.
+    For a band, deviation is 0 inside the band and the distance to the nearest
+    edge outside it; the target is the measured value inside, else the edge.
+
+    Args:
+        measured: Measured angle in degrees (``None`` if unavailable).
+        reference: Point target, ``(min, max)`` band, or ``None``.
+
+    Returns:
+        ``(target, deviation)``. ``target`` is ``None`` when it cannot be
+        resolved; ``deviation`` is 0.0 in that case.
+
+    Example:
+        >>> _target_and_deviation(118.0, (100.0, 130.0))
+        (118.0, 0.0)
+        >>> _target_and_deviation(140.0, (100.0, 130.0))
+        (130.0, 10.0)
+    """
+    if measured is None or reference is None:
+        return (None, 0.0)
+    if isinstance(reference, tuple):
+        lo, hi = reference
+        if measured < lo:
+            return (lo, lo - measured)
+        if measured > hi:
+            return (hi, measured - hi)
+        return (measured, 0.0)
+    return (float(reference), abs(measured - float(reference)))
+
+
+def _deviation_colour(
+    measured: float | None,
+    reference: float | tuple[float, float] | None,
+) -> tuple[int, int, int]:
     """Return a BGR colour based on the angular deviation from reference.
 
     Args:
         measured: Measured angle in degrees (``None`` if not available).
-        reference: Target reference angle in degrees (``None`` if unknown).
+        reference: Target reference angle, ``(min, max)`` band, or ``None``.
 
     Returns:
         BGR colour tuple: dim white (ok), yellow (warning), or red (fault).
@@ -60,7 +100,7 @@ def _deviation_colour(measured: float | None, reference: float | None) -> tuple[
     """
     if measured is None or reference is None:
         return _WHITE_DIM
-    deviation = abs(measured - reference)
+    _target, deviation = _target_and_deviation(measured, reference)
     if deviation < _GOOD_THRESHOLD:
         return _WHITE_DIM
     if deviation < _WARN_THRESHOLD:
@@ -147,13 +187,16 @@ def _rotate_point(
 
 def _find_worst_fault(
     measured_angles: dict[str, float | None],
-    reference_angles: dict[str, float | None],
+    reference_angles: Mapping[str, float | tuple[float, float] | None],
 ) -> tuple[str | None, float]:
     """Find the joint with the largest deviation from reference.
 
+    Supports both point targets and ``(min, max)`` bands (deviation is 0
+    inside a band).
+
     Args:
         measured_angles: Measured joint angles.
-        reference_angles: Reference target angles.
+        reference_angles: Reference targets (point or band) per joint.
 
     Returns:
         Tuple of (joint_name, deviation_degrees). Returns (None, 0) if
@@ -167,7 +210,7 @@ def _find_worst_fault(
         ref = reference_angles.get(joint_name)
         if ref is None:
             continue
-        dev = abs(val - ref)
+        _target, dev = _target_and_deviation(val, ref)
         if dev > worst_dev:
             worst_dev = dev
             worst_joint = joint_name
@@ -178,7 +221,7 @@ def draw_form_diff(
     frame_bgr: np.ndarray,
     landmarks: list,
     measured_angles: dict[str, float | None],
-    reference_angles: dict[str, float | None],
+    reference_angles: Mapping[str, float | tuple[float, float] | None],
     phase_label: str = "",
 ) -> np.ndarray:
     """Draw a clean skeleton overlay focused on the single worst fault.
@@ -206,7 +249,7 @@ def draw_form_diff(
         True
     """
     h, w = frame_bgr.shape[:2]
-    overlay = frame_bgr.copy()
+    overlay: np.ndarray = frame_bgr.copy()
 
     # Find the single worst fault -- always highlight even if within range,
     # because the user sent a video specifically for feedback
@@ -224,9 +267,7 @@ def draw_form_diff(
             continue
 
         # Check if this connection is part of the fault
-        is_fault_segment = (
-            start_idx in fault_joint_indices and end_idx in fault_joint_indices
-        )
+        is_fault_segment = start_idx in fault_joint_indices and end_idx in fault_joint_indices
 
         if is_fault_segment:
             colour = _RED_FAULT if worst_dev >= _WARN_THRESHOLD else _YELLOW_WARN
@@ -239,12 +280,18 @@ def draw_form_diff(
 
     # Draw landmark dots -- larger at the fault vertex
     all_landmarks = [
-        Landmarks.LEFT_SHOULDER, Landmarks.RIGHT_SHOULDER,
-        Landmarks.LEFT_ELBOW, Landmarks.RIGHT_ELBOW,
-        Landmarks.LEFT_WRIST, Landmarks.RIGHT_WRIST,
-        Landmarks.LEFT_HIP, Landmarks.RIGHT_HIP,
-        Landmarks.LEFT_KNEE, Landmarks.RIGHT_KNEE,
-        Landmarks.LEFT_ANKLE, Landmarks.RIGHT_ANKLE,
+        Landmarks.LEFT_SHOULDER,
+        Landmarks.RIGHT_SHOULDER,
+        Landmarks.LEFT_ELBOW,
+        Landmarks.RIGHT_ELBOW,
+        Landmarks.LEFT_WRIST,
+        Landmarks.RIGHT_WRIST,
+        Landmarks.LEFT_HIP,
+        Landmarks.RIGHT_HIP,
+        Landmarks.LEFT_KNEE,
+        Landmarks.RIGHT_KNEE,
+        Landmarks.LEFT_ANKLE,
+        Landmarks.RIGHT_ANKLE,
     ]
     for idx in all_landmarks:
         pt = _get_pixel(landmarks, idx, w, h)
@@ -264,12 +311,29 @@ def draw_form_diff(
         if vertex is not None and actual_end is not None:
             measured_val = measured_angles.get(worst_joint)
             ref_val = reference_angles.get(worst_joint)
-            if measured_val is not None and ref_val is not None:
-                rotation = ref_val - measured_val
+            target_val, _dev = _target_and_deviation(measured_val, ref_val)
+            if measured_val is not None and target_val is not None:
+                rotation = target_val - measured_val
                 ghost_end = _rotate_point(vertex, actual_end, rotation)
                 # Draw bold ghost with dark outline for contrast
-                _draw_dashed_line(overlay, vertex, ghost_end, _BLACK_OUTLINE, _GHOST_THICKNESS + 2, dash_length=14, gap_length=8)
-                _draw_dashed_line(overlay, vertex, ghost_end, _CYAN_GHOST, _GHOST_THICKNESS, dash_length=14, gap_length=8)
+                _draw_dashed_line(
+                    overlay,
+                    vertex,
+                    ghost_end,
+                    _BLACK_OUTLINE,
+                    _GHOST_THICKNESS + 2,
+                    dash_length=14,
+                    gap_length=8,
+                )
+                _draw_dashed_line(
+                    overlay,
+                    vertex,
+                    ghost_end,
+                    _CYAN_GHOST,
+                    _GHOST_THICKNESS,
+                    dash_length=14,
+                    gap_length=8,
+                )
 
     # Phase label at top with dark background for readability
     if phase_label:

--- a/whoopdata/agent/reference_angles.py
+++ b/whoopdata/agent/reference_angles.py
@@ -1,0 +1,192 @@
+"""Phase-keyed reference angle bands for tennis groundstroke analysis.
+
+Single source of truth for the reference angles used by BOTH the visual
+overlay (``pose_overlay.draw_form_diff``) and the LLM prompt text
+(``pose_analysis.AggregatedMetrics.format_for_prompt``). Previously these
+lived in two places (``telegram_bot._REFERENCE_ANGLES`` and the prompt
+markdown) and could diverge.
+
+Design notes (read before changing the numbers):
+
+- **Bands, not points.** Joint angles vary with grip and stroke style
+  (e.g. forehand contact elbow flexion is ~130 deg with an Eastern grip vs
+  ~100 deg with a Western grip [PMC3761830]). A point target would flag
+  correct technique as a fault, so each entry is a ``(min, max)`` band.
+- **2D side-on measurability.** Single-camera markerless pose is reliable for
+  *camera-side, in-plane flexion* (elbow, knee) but unreliable for the
+  occluded far side (~2x error) and for *rotations* (shoulder-hip separation,
+  shoulder internal/external rotation) [PLoS One PMC10635560]. We therefore
+  only grade in-plane flexion here; rotation faults are left to qualitative
+  LLM comment and are NOT encoded as measured bands.
+- **Contact frame is approximate.** Ball contact lasts ~5 ms; at 30 fps a
+  frame is 33 ms, so the captured "contact" frame is near-impact, not impact.
+  Contact bands are deliberately widened to absorb this.
+- **PROVISIONAL — flagged for SME review.** Forehand is anchored to the
+  literature above; backhand joint angles are barely quantified in the
+  literature (only separation angle, a rotation we cannot measure), so
+  backhand grades fewer joints with wider bands and lower confidence.
+
+Joint-name convention matches ``pose_analysis.JOINT_ANGLES``: ``*_flexion``
+is the interior joint angle (180 deg = straight limb, lower = more bent);
+``*_shoulder_elevation`` is the hip-shoulder-elbow angle (higher = arm raised).
+
+Sources:
+    - Forehand review: https://pmc.ncbi.nlm.nih.gov/articles/PMC3761830/
+    - Backhand kinematics: https://pmc.ncbi.nlm.nih.gov/articles/PMC3588639/
+    - 2D markerless validity: https://pmc.ncbi.nlm.nih.gov/articles/PMC10635560/
+"""
+
+from __future__ import annotations
+
+Band = tuple[float, float]
+
+# Ordered groundstroke phase labels (also used by pose_analysis.segment_stroke_phases).
+PHASE_LABELS: tuple[str, ...] = (
+    "preparation",
+    "backswing",
+    "forward_swing",
+    "contact",
+    "follow_through",
+)
+
+GROUNDSTROKE_ACTIVITIES: frozenset[str] = frozenset(
+    {"forehand", "backhand", "groundstroke", "swing", "tennis"}
+)
+
+# Right-handed reference bands, by activity -> phase -> joint -> (min, max) | None.
+# ``None`` means "not graded for this phase" (e.g. trunk_tilt, whose
+# shoulder-hip-knee definition is ambiguous from a single 2D view).
+# Values are mirrored to the left side by ``get_phase_reference``.
+_FOREHAND: dict[str, dict[str, Band | None]] = {
+    # confidence: low — settle before the backswing
+    "preparation": {
+        "right_elbow_flexion": (90.0, 150.0),
+        "right_shoulder_elevation": (20.0, 60.0),
+        "right_knee_flexion": (140.0, 170.0),
+        "trunk_tilt": None,
+    },
+    # confidence: medium — loading; meaningful knee bend, racket taken back
+    "backswing": {
+        "right_elbow_flexion": (90.0, 140.0),
+        "right_shoulder_elevation": (30.0, 80.0),
+        "right_knee_flexion": (120.0, 155.0),
+        "trunk_tilt": None,
+    },
+    # confidence: low — interpolated rising swing
+    "forward_swing": {
+        "right_elbow_flexion": (90.0, 140.0),
+        "right_shoulder_elevation": (60.0, 110.0),
+        "right_knee_flexion": (130.0, 165.0),
+        "trunk_tilt": None,
+    },
+    # confidence: high (elbow) — grip-dependent 100–130 deg [PMC3761830]
+    "contact": {
+        "right_elbow_flexion": (100.0, 130.0),
+        "right_shoulder_elevation": (80.0, 130.0),
+        "right_knee_flexion": (140.0, 175.0),
+        "trunk_tilt": None,
+    },
+    # confidence: low — arm folds across the body, leg extended
+    "follow_through": {
+        "right_elbow_flexion": (40.0, 100.0),
+        "right_shoulder_elevation": (90.0, 140.0),
+        "right_knee_flexion": (150.0, 180.0),
+        "trunk_tilt": None,
+    },
+}
+
+# Backhand: low confidence throughout (literature is thin). One- vs two-handed
+# cannot be distinguished from pose alone, so elbow bands are wide.
+_BACKHAND: dict[str, dict[str, Band | None]] = {
+    "preparation": {
+        "right_elbow_flexion": (80.0, 150.0),
+        "right_knee_flexion": (140.0, 170.0),
+        "trunk_tilt": None,
+    },
+    "backswing": {
+        "right_elbow_flexion": (70.0, 140.0),
+        "right_knee_flexion": (120.0, 155.0),
+        "trunk_tilt": None,
+    },
+    "forward_swing": {
+        "right_elbow_flexion": (90.0, 160.0),
+        "right_knee_flexion": (130.0, 165.0),
+        "trunk_tilt": None,
+    },
+    "contact": {
+        "right_elbow_flexion": (120.0, 175.0),
+        "right_knee_flexion": (140.0, 175.0),
+        "trunk_tilt": None,
+    },
+    "follow_through": {
+        "right_elbow_flexion": (90.0, 175.0),
+        "right_knee_flexion": (150.0, 180.0),
+        "trunk_tilt": None,
+    },
+}
+
+GROUNDSTROKE_REFERENCE: dict[str, dict[str, dict[str, Band | None]]] = {
+    "forehand": _FOREHAND,
+    "backhand": _BACKHAND,
+    # Generic tennis / swing fall back to forehand bands (most common stroke).
+    "swing": _FOREHAND,
+    "groundstroke": _FOREHAND,
+    "tennis": _FOREHAND,
+}
+
+
+def _resolve_activity(activity: str) -> str | None:
+    """Map a free-text caption/activity to a known groundstroke key.
+
+    Args:
+        activity: Caption text or activity label (any case).
+
+    Returns:
+        A key into ``GROUNDSTROKE_REFERENCE``, or ``None`` for non-groundstroke
+        activities (serve, squat, etc.).
+    """
+    text = (activity or "").strip().lower()
+    if not text:
+        return None
+    # Most specific first so "forehand" wins over "tennis".
+    for key in ("forehand", "backhand", "groundstroke", "swing", "tennis"):
+        if key in text:
+            return key
+    return None
+
+
+def get_phase_reference(activity: str, phase_label: str) -> dict[str, Band | None]:
+    """Resolve reference angle bands for an activity + stroke phase.
+
+    Fills both ``left_*`` and ``right_*`` joint keys from the tracked-arm
+    (right-handed reference) value so both sides resolve during overlay.
+
+    Args:
+        activity: Caption/activity text (e.g. ``"analyse my forehand"``).
+        phase_label: One of ``PHASE_LABELS``; unknown phases fall back to
+            ``"contact"``.
+
+    Returns:
+        Mapping of joint name to ``(min, max)`` band or ``None``. Empty dict
+        for non-groundstroke activities.
+
+    Example:
+        >>> band = get_phase_reference("forehand", "contact")["right_elbow_flexion"]
+        >>> band
+        (100.0, 130.0)
+    """
+    key = _resolve_activity(activity)
+    if key is None:
+        return {}
+    phases = GROUNDSTROKE_REFERENCE[key]
+    phase = phases.get(phase_label) or phases.get("contact", {})
+
+    resolved: dict[str, Band | None] = {}
+    for joint, band in phase.items():
+        resolved[joint] = band
+        # Mirror right_* -> left_* (and vice versa) so both sides are graded.
+        if joint.startswith("right_"):
+            resolved[joint.replace("right_", "left_", 1)] = band
+        elif joint.startswith("left_"):
+            resolved[joint.replace("left_", "right_", 1)] = band
+    return resolved

--- a/whoopdata/telegram_bot.py
+++ b/whoopdata/telegram_bot.py
@@ -19,6 +19,7 @@ from telegram.constants import ParseMode
 from whoopdata.agent import settings as agent_settings
 from whoopdata.agent.biomechanics import analyze_video as _default_analyze_video
 from whoopdata.agent.conversation_service import ConversationService, get_conversation_service
+from whoopdata.agent.reference_angles import get_phase_reference
 
 load_dotenv()
 
@@ -27,7 +28,7 @@ _MARKDOWN_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{
 
 
 def _parse_int_set(raw: str | None) -> set[int]:
-    """ parse int set.
+    """parse int set.
 
     Args:
         raw: Input parameter used by this routine.
@@ -35,7 +36,7 @@ def _parse_int_set(raw: str | None) -> set[int]:
     Returns:
         Computed result for this routine.
 
-    
+
     """
     if not raw:
         return set()
@@ -54,17 +55,27 @@ TELEGRAM_ALLOWED_USER_IDS = _parse_int_set(os.getenv("TELEGRAM_ALLOWED_USER_IDS"
 TELEGRAM_ALLOWED_CHAT_IDS = _parse_int_set(os.getenv("TELEGRAM_ALLOWED_CHAT_IDS"))
 
 _DEFAULT_VIDEO_PROMPT = (
-    "These are frames extracted from a video I sent. "
-    "Analyse the movement, form, and any biomechanics overlays visible "
-    "(dots/lines on joints)."
+    "These are phase-labelled frames from a tennis stroke I sent (preparation, "
+    "backswing, forward swing, contact, follow-through), with biomechanics overlays "
+    "(skeleton, fault highlight, dashed reference ghost). Analyse the form across the "
+    "phases using the computed angles below."
 )
 
 _MAX_DENSE_FRAMES = 600
 _MAX_VIDEO_DURATION_SECONDS = 60
+_MAX_LLM_FRAMES = 12  # cap annotated frames sent to the vision model (best+worst x phases)
 _CLIP_TOO_LONG_MSG = (
     "That video is a bit long for detailed analysis. "
-    "For best results, film 3-5 repetitions of the same movement "
-    "(serves, squats, etc.) in a 10-30 second clip, side-on view, full body visible."
+    "For best results, film 3-5 forehands or backhands in a 10-30 second clip, "
+    "side-on with your racket arm toward the camera, full body in frame."
+)
+_VIDEO_TIPS_MSG = (
+    "📹 For the best form analysis, film like this:\n"
+    "• 10-30 seconds, 3-5 forehands or backhands\n"
+    "• Side-on, with your racket arm toward the camera\n"
+    "• Camera held level, your whole body in frame\n"
+    "• Normal speed (no slow-mo); 60 fps if your phone offers it\n"
+    '• Add a caption saying "forehand" or "backhand"'
 )
 
 
@@ -164,76 +175,6 @@ def _extract_video_frames(video_bytes: bytes, *, max_frames: int = 6) -> list[by
     return jpeg_frames
 
 
-# Reference angles for form diff colouring (midpoints of gold-standard ranges)
-_REFERENCE_ANGLES: dict[str, dict[str, float | None]] = {
-    "serve": {
-        "right_elbow_flexion": 30.0,
-        "left_elbow_flexion": 30.0,
-        "right_shoulder_elevation": 111.0,
-        "left_shoulder_elevation": 111.0,
-        "right_knee_flexion": 65.0,
-        "left_knee_flexion": 65.0,
-        "trunk_tilt": 25.0,
-    },
-    "forehand": {
-        "right_elbow_flexion": 90.0,
-        "left_elbow_flexion": 90.0,
-        "right_shoulder_elevation": 80.0,
-        "left_shoulder_elevation": 80.0,
-        "right_knee_flexion": 140.0,
-        "left_knee_flexion": 140.0,
-        "trunk_tilt": 50.0,
-    },
-    "backhand": {
-        "right_elbow_flexion": 100.0,
-        "left_elbow_flexion": 100.0,
-        "right_shoulder_elevation": 75.0,
-        "left_shoulder_elevation": 75.0,
-        "right_knee_flexion": 145.0,
-        "left_knee_flexion": 145.0,
-        "trunk_tilt": 45.0,
-    },
-    "tennis": {
-        "right_elbow_flexion": 90.0,
-        "left_elbow_flexion": 90.0,
-        "right_shoulder_elevation": 80.0,
-        "left_shoulder_elevation": 80.0,
-        "right_knee_flexion": 140.0,
-        "left_knee_flexion": 140.0,
-        "trunk_tilt": 45.0,
-    },
-    "squat": {
-        "right_knee_flexion": 100.0,
-        "left_knee_flexion": 100.0,
-        "trunk_tilt": 45.0,
-        "right_elbow_flexion": None,
-        "left_elbow_flexion": None,
-    },
-    "deadlift": {
-        "right_knee_flexion": 90.0,
-        "left_knee_flexion": 90.0,
-        "trunk_tilt": 45.0,
-    },
-}
-
-
-def _get_reference_angles(activity: str) -> dict[str, float | None]:
-    """Look up reference angles for form diff colouring.
-
-    Args:
-        activity: Activity name from the user's caption.
-
-    Returns:
-        Mapping of joint name to target angle. Returns empty dict
-        for unknown activities (skeleton will be drawn in green).
-    """
-    normalised = activity.strip().lower()
-    for key, angles in _REFERENCE_ANGLES.items():
-        if key in normalised:
-            return angles
-    return {}
-
-
 def _preprocess_frames(frames: list[bytes]) -> list[bytes]:
     """Legacy preprocessing stub (pass-through).
 
@@ -251,10 +192,8 @@ def _preprocess_frames(frames: list[bytes]) -> list[bytes]:
 
 @dataclass
 class OutboundTelegramMessage:
-    """OutboundTelegramMessage data structure or service type.
+    """OutboundTelegramMessage data structure or service type."""
 
-    
-    """
     text: str | None = None
     photo_bytes: bytes | None = None
     voice_bytes: bytes | None = None
@@ -274,12 +213,11 @@ def session_id_for_chat(chat_id: int) -> str:
 
 @dataclass
 class ConversationBinding:
-    """ConversationBinding data structure or service type.
+    """ConversationBinding data structure or service type."""
 
-    
-    """
     session_id: str | None = None
     thread_id: str | None = None
+    seen_video: bool = False
 
 
 class TelegramConversationGateway:
@@ -323,7 +261,7 @@ class TelegramConversationGateway:
             result = is_authorized(user_id=..., chat_id=..., chat_type=...)
             _ = result
 
-        
+
         """
         if user_id is None or chat_id is None:
             return False
@@ -357,7 +295,7 @@ class TelegramConversationGateway:
             result = build_whoami_messages(user_id=..., chat_id=..., chat_type=...)
             _ = result
 
-        
+
         """
         return [
             OutboundTelegramMessage(
@@ -398,7 +336,7 @@ class TelegramConversationGateway:
             result = await handle_text_message(text=..., user_id=..., chat_id=..., chat_type=..., image_b64=...)
             _ = result
 
-        
+
         """
         if not self.is_authorized(user_id=user_id, chat_id=chat_id, chat_type=chat_type):
             return []
@@ -557,53 +495,85 @@ class TelegramConversationGateway:
         analyser = PoseAnalyser(activity=activity or None)
         result: AnalysisResult = analyser.analyse_frames(frames_bgr, fps)
 
-        # Build annotated key frames
-        # Reference angles for form diff (simplified -- use midpoint of gold-standard ranges)
-        reference_angles = _get_reference_angles(activity)
+        # First-video filming tips (once per chat) + any soft warnings, shown
+        # before the annotated frames so expectations are set up front.
+        prefix_messages: list[OutboundTelegramMessage] = []
+        if chat_id is not None:
+            binding = self._bindings_by_chat.setdefault(
+                chat_id,
+                ConversationBinding(
+                    session_id=session_id_for_chat(chat_id),
+                    thread_id=thread_id_for_chat(chat_id),
+                ),
+            )
+            if not binding.seen_video:
+                prefix_messages.append(OutboundTelegramMessage(text=_VIDEO_TIPS_MSG))
+                binding.seen_video = True
+        for warning in result.metrics.warnings:
+            prefix_messages.append(OutboundTelegramMessage(text=warning))
+
+        # Build annotated phase-strip frames (best + worst rep), one frame per
+        # phase, each graded against that phase's evidence-based reference band.
         annotated_photos: list[OutboundTelegramMessage] = []
         annotated_for_archive: list[tuple[Any, str]] = []
 
-        for key_idx in result.metrics.key_frame_indices:
-            if key_idx >= len(frames_bgr) or result.all_landmarks[key_idx] is None:
-                continue
-
-            frame = frames_bgr[key_idx]
-            landmarks = result.all_landmarks[key_idx]
-            measured = result.all_angles[key_idx].angles
-
-            # Find which rep this frame belongs to
-            rep_label = ""
-            for rep in result.metrics.per_rep:
-                if rep.event.start_frame <= key_idx <= rep.event.end_frame:
-                    rep_label = f"{rep.event.event_type} -- Rep {rep.rep_number}/{result.metrics.num_reps}"
+        for strip in result.metrics.key_phase_strips:
+            if len(annotated_photos) >= _MAX_LLM_FRAMES:
+                break
+            for phase_label, frame_idx in strip.phases:
+                if len(annotated_photos) >= _MAX_LLM_FRAMES:
                     break
+                if not (0 <= frame_idx < len(frames_bgr)):
+                    continue
+                landmarks = result.all_landmarks[frame_idx]
+                if landmarks is None:
+                    continue
 
-            annotated = draw_form_diff(
-                frame, landmarks, measured, reference_angles, phase_label=rep_label
-            )
-            photo_bytes = encode_annotated_frame(annotated)
-            annotated_for_archive.append((annotated, rep_label))
+                frame = frames_bgr[frame_idx]
+                measured = result.all_angles[frame_idx].angles
+                refs = get_phase_reference(strip.event_type, phase_label)
+                label = f"{strip.event_type} rep {strip.rep_number} -- {phase_label}"
 
-            # Build a short caption with the key angle deviation
-            cap_parts = [rep_label] if rep_label else []
-            for joint, val in measured.items():
-                ref = reference_angles.get(joint)
-                if val is not None and ref is not None and abs(val - ref) >= 15:
-                    cap_parts.append(f"{joint}: {int(val)} deg (target: {int(ref)})")
-                    break  # One deviation per caption
-            photo_caption = " -- ".join(cap_parts) if cap_parts else "Pose analysis"
+                annotated = draw_form_diff(frame, landmarks, measured, refs, phase_label=label)
+                photo_bytes = encode_annotated_frame(annotated)
+                annotated_for_archive.append((annotated, label))
 
-            annotated_photos.append(
-                OutboundTelegramMessage(photo_bytes=photo_bytes, caption=photo_caption)
-            )
+                # Caption: phase label + the most out-of-band graded joint, if any.
+                cap_parts = [label]
+                worst_joint, worst_band, worst_val, worst_dev = None, None, None, 0.0
+                for joint, band in refs.items():
+                    val = measured.get(joint)
+                    if val is None or band is None:
+                        continue
+                    lo, hi = band
+                    dev = (lo - val) if val < lo else ((val - hi) if val > hi else 0.0)
+                    if dev > worst_dev:
+                        worst_dev, worst_joint, worst_band, worst_val = dev, joint, band, val
+                if (
+                    worst_joint
+                    and worst_band is not None
+                    and worst_val is not None
+                    and worst_dev >= 15
+                ):
+                    short = worst_joint.replace("_flexion", "").replace("_", " ")
+                    cap_parts.append(
+                        f"{short}: {int(worst_val)} deg "
+                        f"(target {int(worst_band[0])}-{int(worst_band[1])})"
+                    )
 
-        # Build overlay for ALL frames (for local archive review)
+                annotated_photos.append(
+                    OutboundTelegramMessage(photo_bytes=photo_bytes, caption=" -- ".join(cap_parts))
+                )
+
+        # Build overlay for ALL frames (for local archive review). Use the
+        # contact-phase reference as a single representative target.
+        archive_reference = get_phase_reference(activity, "contact")
         all_overlay_frames: list[Any] = []
         for i, frame in enumerate(frames_bgr):
             if result.all_landmarks[i] is not None:
                 measured = result.all_angles[i].angles
                 overlay = draw_form_diff(
-                    frame, result.all_landmarks[i], measured, reference_angles
+                    frame, result.all_landmarks[i], measured, archive_reference
                 )
                 all_overlay_frames.append(overlay)
             else:
@@ -627,8 +597,9 @@ class TelegramConversationGateway:
         except Exception:
             logger.warning("Failed to save video analysis archive", exc_info=True)
 
-        # Build LLM prompt with structured metrics + key frames
-        metrics_text = result.metrics.format_for_prompt(reference_angles=reference_angles)
+        # Build LLM prompt with structured metrics + key frames. format_for_prompt
+        # already prepends any soft warnings as NOTE lines, so the model can hedge.
+        metrics_text = result.metrics.format_for_prompt()
         key_frame_b64 = []
         for msg in annotated_photos:
             if msg.photo_bytes:
@@ -643,9 +614,15 @@ class TelegramConversationGateway:
             )
         except Exception:
             logger.exception("Biomechanics agent failed")
-            return annotated_photos + [
-                OutboundTelegramMessage(text="Sorry, I hit an error with the coaching analysis.")
-            ]
+            return (
+                prefix_messages
+                + annotated_photos
+                + [
+                    OutboundTelegramMessage(
+                        text="Sorry, I hit an error with the coaching analysis."
+                    )
+                ]
+            )
 
         # Stage 3: supervisor synthesis
         supervisor_prompt = (
@@ -662,8 +639,8 @@ class TelegramConversationGateway:
             chat_type=chat_type,
         )
 
-        # Send annotated photos first, then text
-        return annotated_photos + text_responses
+        # Tips/warnings first, then annotated photos, then coaching text.
+        return prefix_messages + annotated_photos + text_responses
 
     async def _handle_video_legacy(
         self,
@@ -686,14 +663,10 @@ class TelegramConversationGateway:
         images_b64 = [base64.b64encode(f).decode("utf-8") for f in raw_frames]
         prompt = caption or _DEFAULT_VIDEO_PROMPT
         try:
-            analysis = await self._analyze_video(
-                images_b64, prompt, user_id=f"telegram:{user_id}"
-            )
+            analysis = await self._analyze_video(images_b64, prompt, user_id=f"telegram:{user_id}")
         except Exception:
             logger.exception("Biomechanics video analysis failed")
-            return [
-                OutboundTelegramMessage(text="Sorry, I hit an error analysing that video.")
-            ]
+            return [OutboundTelegramMessage(text="Sorry, I hit an error analysing that video.")]
 
         supervisor_prompt = (
             "The user sent a video. Here is the biomechanics analysis from the "
@@ -711,7 +684,7 @@ class TelegramConversationGateway:
     def _build_response_messages(
         self, assistant_message: str, artifacts: list
     ) -> list[OutboundTelegramMessage]:
-        """ build response messages.
+        """build response messages.
 
         Args:
             assistant_message: Input parameter used by this routine.
@@ -720,7 +693,7 @@ class TelegramConversationGateway:
         Returns:
             Computed result for this routine.
 
-        
+
         """
         messages: list[OutboundTelegramMessage] = []
 
@@ -812,7 +785,7 @@ def _strip_html_tags(text: str) -> str:
 
 
 def _strip_markdown_inline_markup(text: str) -> str:
-    """ strip markdown inline markup.
+    """strip markdown inline markup.
 
     Args:
         text: Input parameter used by this routine.
@@ -820,7 +793,7 @@ def _strip_markdown_inline_markup(text: str) -> str:
     Returns:
         Computed result for this routine.
 
-    
+
     """
     text = re.sub(r"`([^`\n]+)`", r"\1", text)
     text = re.sub(r"\*\*([^\n*][^*]*?)\*\*", r"\1", text)
@@ -831,7 +804,7 @@ def _strip_markdown_inline_markup(text: str) -> str:
 
 
 def _normalize_telegram_plain_line(text: str) -> str:
-    """ normalize telegram plain line.
+    """normalize telegram plain line.
 
     Args:
         text: Input parameter used by this routine.
@@ -839,7 +812,7 @@ def _normalize_telegram_plain_line(text: str) -> str:
     Returns:
         Computed result for this routine.
 
-    
+
     """
     line = text.strip()
     if not line:
@@ -854,7 +827,7 @@ def _normalize_telegram_plain_line(text: str) -> str:
 
 
 def _flatten_markdown_table_row(line: str) -> str:
-    """ flatten markdown table row.
+    """flatten markdown table row.
 
     Args:
         line: Input parameter used by this routine.
@@ -862,7 +835,7 @@ def _flatten_markdown_table_row(line: str) -> str:
     Returns:
         Computed result for this routine.
 
-    
+
     """
     cells = [_normalize_telegram_plain_line(cell) for cell in line.strip().strip("|").split("|")]
     cells = [cell for cell in cells if cell]
@@ -874,7 +847,7 @@ def _flatten_markdown_table_row(line: str) -> str:
 
 
 def _truncate_telegram_plain_text(text: str, *, max_chars: int) -> str:
-    """ truncate telegram plain text.
+    """truncate telegram plain text.
 
     Args:
         text: Input parameter used by this routine.
@@ -883,7 +856,7 @@ def _truncate_telegram_plain_text(text: str, *, max_chars: int) -> str:
     Returns:
         Computed result for this routine.
 
-    
+
     """
     if len(text) <= max_chars:
         return text
@@ -929,7 +902,7 @@ def format_text_for_telegram_plain(
         result = format_text_for_telegram_plain(text=..., max_chars=..., max_lines=...)
         _ = result
 
-    
+
     """
     raw_lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
     cleaned_lines: list[str] = []
@@ -1009,7 +982,7 @@ def format_text_for_telegram_html(text: str) -> str:
         result = format_text_for_telegram_html(text=...)
         _ = result
 
-    
+
     """
     escaped = html.escape(text)
     escaped = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", escaped)
@@ -1022,12 +995,12 @@ def format_text_for_telegram_html(text: str) -> str:
 
 
 def _build_gateway() -> TelegramConversationGateway:
-    """ build gateway.
+    """build gateway.
 
     Returns:
         Computed result for this routine.
 
-    
+
     """
     return TelegramConversationGateway(
         allowed_user_ids=TELEGRAM_ALLOWED_USER_IDS,
@@ -1036,13 +1009,13 @@ def _build_gateway() -> TelegramConversationGateway:
 
 
 async def _reply(update, messages: list[OutboundTelegramMessage]) -> None:
-    """ reply.
+    """reply.
 
     Args:
         update: Input parameter used by this routine.
         messages: Input parameter used by this routine.
 
-    
+
     """
     message = update.effective_message
     if message is None:
@@ -1069,7 +1042,7 @@ async def start_command(update, context) -> None:
         result = await start_command(update=..., context=...)
         _ = result
 
-    
+
     """
     gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
     user = update.effective_user
@@ -1080,7 +1053,9 @@ async def start_command(update, context) -> None:
             text=(
                 "Health Data Agent is online.\n"
                 "Use `/whoami` to capture your Telegram IDs for allowlisting, then add "
-                "`TELEGRAM_ALLOWED_USER_IDS` and `TELEGRAM_ALLOWED_CHAT_IDS` to `.env`."
+                "`TELEGRAM_ALLOWED_USER_IDS` and `TELEGRAM_ALLOWED_CHAT_IDS` to `.env`.\n"
+                "Send a tennis video (forehand/backhand) for form analysis — "
+                "use /videotips for how to film it."
             )
         )
     ]
@@ -1107,7 +1082,7 @@ async def whoami_command(update, context) -> None:
         result = await whoami_command(update=..., context=...)
         _ = result
 
-    
+
     """
     gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
     user = update.effective_user
@@ -1122,6 +1097,16 @@ async def whoami_command(update, context) -> None:
     )
 
 
+async def videotips_command(update, context) -> None:
+    """Reply with guidance on how to film a tennis stroke for form analysis.
+
+    Args:
+        update: Telegram update.
+        context: Telegram callback context.
+    """
+    await _reply(update, [OutboundTelegramMessage(text=_VIDEO_TIPS_MSG)])
+
+
 async def text_message(update, context) -> None:
     """Text message.
 
@@ -1134,7 +1119,7 @@ async def text_message(update, context) -> None:
         result = await text_message(update=..., context=...)
         _ = result
 
-    
+
     """
     gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
     user = update.effective_user
@@ -1165,7 +1150,7 @@ async def voice_message(update, context) -> None:
         result = await voice_message(update=..., context=...)
         _ = result
 
-    
+
     """
     gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
     user = update.effective_user
@@ -1208,7 +1193,7 @@ async def photo_message(update, context) -> None:
         result = await photo_message(update=..., context=...)
         _ = result
 
-    
+
     """
     gateway: TelegramConversationGateway = context.application.bot_data["gateway"]
     user = update.effective_user
@@ -1292,7 +1277,7 @@ async def error_handler(update, context) -> None:
         result = await error_handler(update=..., context=...)
         _ = result
 
-    
+
     """
     logger.exception("Telegram bot error: %s", context.error)
     if getattr(update, "effective_message", None) is not None:
@@ -1313,7 +1298,7 @@ def build_application(gateway: TelegramConversationGateway | None = None):
         result = build_application(gateway=...)
         _ = result
 
-    
+
     """
     if not TELEGRAM_BOT_TOKEN:
         raise RuntimeError("TELEGRAM_BOT_TOKEN is required to start the Telegram bot")
@@ -1324,6 +1309,7 @@ def build_application(gateway: TelegramConversationGateway | None = None):
     application.bot_data["gateway"] = gateway or _build_gateway()
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("whoami", whoami_command))
+    application.add_handler(CommandHandler("videotips", videotips_command))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, text_message))
     application.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, voice_message))
     application.add_handler(MessageHandler(filters.PHOTO, photo_message))
@@ -1340,7 +1326,7 @@ async def run_bot() -> None:
         result = await run_bot()
         _ = result
 
-    
+
     """
     application = build_application()
     await application.initialize()
@@ -1363,7 +1349,7 @@ def main() -> None:
         result = main()
         _ = result
 
-    
+
     """
     logging.basicConfig(level=logging.INFO)
     asyncio.run(run_bot())


### PR DESCRIPTION
## Why
The tennis video form-analysis feature looked impressive but didn't work: the LLM only ever saw 1–2 frames (the peak of the best/worst rep, or a single middle frame when rep detection silently failed), so it couldn't reason about a multi-phase stroke. Reference angles were duplicated across two files and could diverge.

## What
- **Phase strips** — `segment_stroke_phases()` carves each forehand/backhand into preparation → backswing → forward swing → contact → follow-through; the best and worst rep are sent as ~8–12 phase-labelled annotated frames (capped at 12).
- **Single source of truth for references** — new `reference_angles.py` with phase-keyed **bands** (not point targets). Forehand is literature-anchored (contact elbow 100–130°, grip-dependent); backhand is wider/low-confidence. Removed the duplicated `telegram_bot._REFERENCE_ANGLES`.
- **Kinetic-chain timing** — orders hip→shoulder→elbow→wrist by peak-speed time; flags arm-led strokes (measurable from 2D even where rotation isn't).
- **Robustness UX** — soft warnings (low tracking, no reps → spaced fallback, single rep) + an orientation gate (racket arm occluded), shown to the user and injected into the prompt. New `/videotips` command + first-video hint.
- **Honest measurability** — prompt now treats the contact frame as approximate (~5 ms contact vs 30 fps) and forbids presenting rotation (e.g. shoulder-hip separation) as measured.

Scope: tennis **forehand + backhand** only. Research basis: PMC3761830 (forehand), PMC3588639 (backhand), PMC10635560 (2D markerless validity), arXiv 2506.08327 (contact duration).

## Release
Minor bump **3.9.0 → 3.10.0** (`whoopdata/__version__.py`, `pyproject.toml`) + CHANGELOG entry. Tag + GitHub release to follow on merge.

## Verification
- 91 tests pass across pose / agent-architecture / telegram-boundary suites (~15 new).
- `black --check`, `ruff`, and `mypy` clean on changed files.
- ⚠️ Not run end-to-end (needs MediaPipe + a real clip + Telegram runtime).
- ⚠️ Reference bands are **provisional**, flagged for SME review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)