### PR TITLE
Add database schema reference (WHOOP/Withings + two-database overview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ backed by Postgres (with an in-memory fallback for development), so threads and 
 restarts and are shared across every transport.
 
 > Architecture deep-dive, module map, and prompt design: [`whoopdata/agent/README.md`](whoopdata/agent/README.md).
+> Data model and the two-database split (SQLite domain data, Postgres agent persistence):
+> [`docs/technical/DATABASE_SCHEMA.md`](docs/technical/DATABASE_SCHEMA.md).
 > The platform is ~27k lines across ~109 Python modules with ~30 test suites.
 
 ## Tech stack

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## 📁 Documentation Structure
 
 ### Technical Documentation (`technical/`)
+- **[Database Schema](technical/DATABASE_SCHEMA.md)** - The two databases (SQLite domain data, Postgres agent persistence) and the WHOOP/Withings entity-relationship diagram
 - **[API Consolidation Summary](technical/API_CONSOLIDATION_SUMMARY.md)** - Complete overhaul of API endpoints with unified structure
 - **[Backward Compatibility Solution](technical/BACKWARD_COMPATIBILITY_SOLUTION.md)** - Two-tier API architecture maintaining website compatibility  
 - **[Database Issues Fixed](technical/DATABASE_ISSUES_FIXED.md)** - Resolution of data ordering and filtering problems

--- a/docs/technical/DATABASE_SCHEMA.md
+++ b/docs/technical/DATABASE_SCHEMA.md
@@ -1,0 +1,120 @@
+# Database Schema
+
+This project uses **two databases**, each with a distinct job. Diagrams below show primary keys,
+foreign keys, and a few representative fields per table -- not every column. The source of truth for
+the SQLite schema is the SQLAlchemy models in `whoopdata/models/models.py`; keep this document in sync
+when those models change.
+
+## The two databases
+
+| Database | Where | Holds |
+|---|---|---|
+| **SQLite** | `whoopdata/database/whoop.db` (engine in `whoopdata/database/database.py`) | All domain and application data: WHOOP, Withings, the daily engine, the proactive-message log, and the biomarker tables. Defined by the shared SQLAlchemy `Base`. |
+| **PostgreSQL** | Docker container `whoop-agent-postgres`, database `whoop_agent`, port 5432 (see `docker-compose.yml`) | The LangGraph **agent persistence** layer only -- conversation state and long-term memory. Built in `whoopdata/agent/persistence.py`. |
+
+### How the Postgres (agent persistence) database is used
+
+`whoopdata/agent/persistence.py` provisions two LangGraph resources against `AGENT_POSTGRES_URL`:
+
+- **Checkpointer** (`AsyncPostgresSaver`) -- persists conversation/thread state so a Telegram or UI
+  conversation can resume across messages, keyed by `thread_id`.
+- **Long-term memory store** (`AsyncPostgresStore`) -- backs the `search_memory` / `manage_memory`
+  tools (`whoopdata/agent/memory_tools.py`). Memories are namespaced per user and **category**:
+  `profile`, `goal`, `constraint`, `commitment`, `observation`.
+
+Notes:
+
+- If `AGENT_POSTGRES_URL` is not set, persistence falls back to in-memory
+  (`InMemorySaver` / `InMemoryStore`) and nothing survives a restart.
+- The tables in this database are created and managed by LangGraph itself (via `.setup()`), not by our
+  SQLAlchemy models, so they are not drawn below.
+- On retrieval, `search_memory` passes a natural-language `query` to the store. True vector-*semantic*
+  ranking requires an embeddings index to be configured on the store; `persistence.py` does not set
+  one today, so retrieval is currently scoped by user and category rather than by semantic similarity.
+  Adding an embeddings index to `AsyncPostgresStore` would make it semantic.
+
+## SQLite: WHOOP and Withings data
+
+```mermaid
+erDiagram
+    CYCLES ||--o{ RECOVERY : "has"
+    CYCLES ||--o{ WORKOUT : "has"
+    SLEEP  ||--o{ RECOVERY : "scored from"
+
+    CYCLES {
+        int id PK
+        string user_id
+        datetime start
+        datetime end
+        float strain
+        float kilojoule
+        float average_heart_rate
+    }
+    SLEEP {
+        int id PK
+        string whoop_id UK
+        string user_id
+        float sleep_performance_percentage
+        float sleep_efficiency_percentage
+        int total_rem_sleep_time_milli
+        int total_slow_wave_sleep_time_milli
+    }
+    RECOVERY {
+        int id PK
+        int cycle_id FK
+        int sleep_id FK
+        float recovery_score
+        float hrv_rmssd_milli
+        float resting_heart_rate
+        float spo2_percentage
+        float skin_temp_celsius
+    }
+    WORKOUT {
+        int id PK
+        string whoop_id UK
+        int cycle_id FK
+        int sport_id
+        float strain
+        float average_heart_rate
+        float zone_two_minutes
+    }
+    WITHINGS_WEIGHT {
+        int id PK
+        string user_id
+        datetime datetime
+        float weight_kg
+        float fat_ratio_percent
+        float muscle_mass_kg
+    }
+    WITHINGS_HEART_RATE {
+        int id PK
+        string user_id
+        datetime datetime
+        float heart_rate_bpm
+        float systolic_bp_mmhg
+        float diastolic_bp_mmhg
+    }
+```
+
+### Relationships and joins
+
+- `recovery.cycle_id -> cycles.id` and `recovery.sleep_id -> sleep.id`: each recovery score belongs to
+  one WHOOP cycle and is scored from one sleep.
+- `workout.cycle_id -> cycles.id`: each workout belongs to one cycle.
+- `sleep.whoop_id` and `workout.whoop_id` are unique WHOOP API identifiers.
+- `withings_weight` and `withings_heart_rate` have **no database-level foreign keys**. They are
+  independent measurement streams from the Withings scale/device and relate to the WHOOP data only
+  logically, by `user_id` and timestamp.
+
+## Other tables in the same SQLite database
+
+These live in `whoop.db` alongside the data above but are derived or operational rather than raw
+device data:
+
+- `recommendations` (PK `id`) and `recommendation_outcomes` (PK `id`, FK `recommendation_id -> recommendations.id`)
+  -- daily-engine recommendations and whether they were followed.
+- `proactive_message_log` (PK `id`) -- log of proactive (JITAI) nudges, used to apply cooldowns and
+  escalation.
+- `biomarker_report`, `biomarker_results`, `biomarker_education`, `safety_audit` -- the biomarker
+  analyser tables, documented separately in
+  [`../features/BIOMARKER_SCHEMA.md`](../features/BIOMARKER_SCHEMA.md).


### PR DESCRIPTION
Adds `docs/technical/DATABASE_SCHEMA.md`, a single reference for the project data model.

### What it documents
- **The two databases and their roles.** SQLite (`whoopdata/database/whoop.db`) holds all domain data; PostgreSQL (the Docker `whoop-agent-postgres` container, enabled via `AGENT_POSTGRES_URL`) holds only the LangGraph agent persistence -- the checkpointer (conversation/thread state) and the long-term memory store behind `search_memory` / `manage_memory`. The note records the in-memory fallback when `AGENT_POSTGRES_URL` is unset, that those tables are LangGraph-managed, and that vector-semantic ranking would require an embeddings index that is not currently configured.
- **A Mermaid entity-relationship diagram** for the WHOOP and Withings tables (`cycles`, `sleep`, `recovery`, `workout`, `withings_weight`, `withings_heart_rate`) with primary keys, foreign keys, and representative fields. Cross-checked against `whoopdata/models/models.py` and validated as a Mermaid er diagram.
- **A brief inventory** of the other tables in the same SQLite database, with a cross-link to `docs/features/BIOMARKER_SCHEMA.md`.

Discoverability links added from `README.md` and `docs/README.md`. Documentation only; no code changes.

Generated with [Claude Code](https://claude.com/claude-code)