### PR TITLE
feat(biomarkers): Emerald knowledge grounding via pgvector RAG (v3.14.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ private/
 *.xlsx
 health_data/
 exports/
+
+# Local DB backups (pg_dump)
+.backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the WHOOP Data Platform will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.14.0] - 2026-06-21
+
+### Added
+- Vetted-knowledge grounding for the `biomarkers` specialist (Emerald RAG). A new read-only `get_biomarker_knowledge` tool retrieves general, source-attributed information about a biomarker from Emerald's knowledge base (https://withemerald.com/knowledge/biomarker), backed by a pgvector vector store. ~119 biomarker pages (1,548 chunks) are embedded with OpenAI `text-embedding-3-small` into the `emerald_biomarker_kb` collection.
+- `whoopdata/knowledge/` package: `biomarker_kb.py` (shared `PGVector` store builder that degrades gracefully to `None`/fallback when Postgres or pgvector is unavailable) and `ingest_biomarker_kb.py` (`python -m` ingestion: recursive markdown walk, header-aware chunking, deterministic ids for idempotent upserts, and a lenient parser for frontmatter whose values contain unquoted colons).
+- `tests/test_biomarker_kb_ingest.py`: frontmatter/chunk-metadata parsing and the retrieval tool's graceful-fallback path.
+
+### Changed
+- The `biomarkers` sub-agent prompt (`data/prompts/agents/biomarkers_sub_agent.md`) now treats `get_biomarker_knowledge` as the primary education source and forbids attributing anything to Emerald that a tool call did not return in the same turn -- preventing fabricated "Per Emerald" attribution sourced from the model's own memory. The no-bridging serving contract is unchanged: general knowledge is served stand-alone and never tied to the user's own value.
+- `docs/features/BIOMARKER_INTENDED_PURPOSE.md`: added a "vetted knowledge grounding" amendment. The KB is a general, non-personalised, source-attributed library (not a device function); the medical-purpose risk is *juxtaposition* with the user's value, controlled by the serving contract rather than by stripping the corpus.
+- `docker-compose.yml`: the Postgres service now uses `pgvector/pgvector:pg16` (a superset of stock `postgres:16`) so a single instance serves both agent persistence and the biomarker KB.
+- Dependencies: added `langchain-postgres` and `pgvector`.
+
+### Notes
+- The `get_biomarker_knowledge` tool is given only to the biomarker specialist, not the supervisor, so the no-bridging guardrail stays in a single prompt; the supervisor is where the user's value and general knowledge would otherwise be juxtaposed.
+- The scraped Emerald corpus is not committed (the `data/` directory is gitignored); it is reproducible by re-running `python -m whoopdata.knowledge.ingest_biomarker_kb`.
+- Operators with an existing stock-`postgres:16` agent-persistence container must recreate it on the pgvector image (`pg_dump` -> recreate -> `pg_restore`) to enable the KB. Until then the retrieval tool degrades gracefully and the agent falls back to the `get_biomarker_education` glossary.
+
 ## [3.13.1] - 2026-06-20
 
 ### Fixed

--- a/data/prompts/agents/biomarkers_sub_agent.md
+++ b/data/prompts/agents/biomarkers_sub_agent.md
@@ -4,28 +4,44 @@ You are a blood biomarker information assistant for a personal prototype, your j
 Your job is strictly limited. You may:
 - Show the user the **value** of a biomarker from their most recent lab report.
 - Show the **reference range** that the testing laboratory itself provided.
-- Give **generic education**: what a biomarker **is** and its **normal physiological function**
-  (use the `get_biomarker_education` tool — never invent this).
+- Provide **education and general knowledge** about a biomarker. Emerald's knowledge base is your
+  **primary source** for this — call `get_biomarker_knowledge` whenever the user asks what a
+  biomarker is/does/means, "what does Emerald say", or for any general information. It is reference
+  material *about the biomarker in general* and may include what elevated or low levels generally
+  indicate. `get_biomarker_education` is a small fallback glossary for the bare definition only.
 - Organise results by their body-system group.
 
+**Sourcing & attribution (mandatory):**
+- You may only attribute something to Emerald if it came from a `get_biomarker_knowledge` call in
+  *this* turn. **Never** write "Per Emerald" / "Emerald's note" from your own memory.
+- If `get_biomarker_knowledge` returns no passages (or is unavailable) and the glossary has no
+  entry, say you don't have vetted information on that biomarker — do **not** fabricate education or
+  invent an attribution. Relay only what the tools return; do not supplement from your own knowledge.
+
 You must NEVER:
-- Say or imply whether a result is **high, low, abnormal, normal, optimal, or out of range** — even
-  if it obviously is, and even if the user asks directly. You do not provide the verdict.
-- **Interpret** the user's result, **diagnose**, **screen**, **predict**, or relate a result to any
-  **disease or condition**.
-- Describe what **high or low** levels of a biomarker indicate, mean, or cause.
+- Say or imply whether **the user's own result** is **high, low, abnormal, normal, optimal, or out
+  of range** — even if it obviously is, and even if the user asks directly. You do not provide the
+  verdict on their value.
+- **Bridge** general knowledge to the user's specific number. Keep the two separate: you may state
+  the user's value + the lab's range, and separately state Emerald's general knowledge, but you must
+  NOT connect them ("your 145 is elevated, which means…"). The user draws their own conclusions; you
+  do not perform that inference for them.
+- **Interpret** the user's result, **diagnose**, **screen**, **predict**, or relate **their** result
+  to any **disease or condition**.
 - Recommend treatment, supplements, dosing, or any care decision.
 - Compare results over time or describe a **trend** (only one report exists).
 
 How to handle common requests:
-- "What is my LDL?" → state the value, unit, and the lab's range; optionally add generic education.
-- "What does my LDL mean?" → give generic education about what LDL **is** and does; do not interpret
-  the user's number.
+- "What is my LDL?" → state the value, unit, and the lab's range; optionally call
+  `get_biomarker_knowledge` to add attributed general education.
+- "What does my LDL mean?" / "What does Emerald say about LDL?" → call `get_biomarker_knowledge` and
+  relay the vetted general information with attribution. Do not tie it to the user's value.
 - "Is my glucose high / bad / normal?" → do **not** answer the verdict. State the value and the lab's
   range, note that you don't interpret individual results, and suggest they speak to a clinician for
-  what it means for them.
+  what it means for them. You may call `get_biomarker_knowledge` to add attributed general knowledge
+  about glucose, but never say their number is high/low or what *their* number implies.
 
 Always be factual, calm, and brief. For any interpretation of their results, direct the user to a
 clinician. This boundary is mandatory and you are solely responsible for upholding it on every
 reply — there is no downstream check, so never state or imply a verdict, interpretation, diagnosis,
-or trend.
+or trend on the user's own value, and never bridge general (Emerald) knowledge to their specific result.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  postgres:
+    # pgvector image = stock Postgres 16 + the `vector` extension, used both for
+    # agent persistence and the biomarker knowledge base (Emerald RAG).
+    image: pgvector/pgvector:pg16
+    container_name: whoop-agent-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: whoop_agent
+    ports:
+      - "5432:5432"
+    volumes:
+      - whoop-agent-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  whoop-agent-postgres-data:

--- a/docs/features/BIOMARKER_INTENDED_PURPOSE.md
+++ b/docs/features/BIOMARKER_INTENDED_PURPOSE.md
@@ -66,13 +66,41 @@ tweak.
 
 ## The education boundary (Step 6 line — the live drift edge)
 
-Generic education may describe **what a biomarker is** and its **normal physiological function**. It
-must stop *before* any consequence-of-abnormal.
+Generic education from the DB glossary (`get_biomarker_education`) describes **what a biomarker is**
+and its **normal physiological function**, and stops *before* any consequence-of-abnormal.
 
 - ✅ Allowed: *"LDL is a lipoprotein that carries cholesterol around the body. Cholesterol is used to
   build cells and make hormones."*
-- ⛔ Blocked: *"High LDL is linked to heart disease." · "Low B12 can cause fatigue." · "Your level
-  suggests…"*
+- ⛔ Blocked from the glossary tool: *"High LDL is linked to heart disease." · "Your level suggests…"*
+
+This baseline is **extended — not removed —** by the vetted-knowledge amendment below.
+
+---
+
+## Amendment: vetted knowledge grounding (Emerald RAG)
+
+The agent may additionally serve **vetted, source-attributed general knowledge** from Emerald's
+public knowledge base via `get_biomarker_knowledge` (pgvector RAG over scraped markdown). This content
+*may* include what elevated/low levels **generally** indicate.
+
+**Why this stays outside the device definition (first-principles):** the medical-purpose hinge is
+whether software *processes a specific individual's data to produce a patient-specific output for a
+clinical purpose*. A static, general, source-attributed knowledge article is **general medical
+information** — the same category as a textbook or the lab's own leaflet — not applied to the
+individual. A library is not a device. The risk lives entirely in **juxtaposition**: placing a
+general "elevated LDL means X" *next to* the user's own "LDL 145" in the same answer reconstructs an
+individualised interpretation. So the controllable variable is the **serving contract**, not the
+corpus.
+
+**The load-bearing control is the no-bridging rule:**
+
+- ✅ Allowed: *"Per Emerald's knowledge base, elevated LDL is generally associated with cardiovascular
+  risk."* (general, attributed, stands alone)
+- ⛔ Still blocked: bridging it to the user's number — *"your 145 is elevated, which means…"* — or any
+  verdict / interpretation / diagnosis / trend on **their** value.
+
+This is a deliberate scope decision for the prototype: the corpus is rich; the boundary is enforced at
+serving time by the sub-agent prompt's no-bridging contract.
 
 ---
 
@@ -80,10 +108,14 @@ must stop *before* any consequence-of-abnormal.
 
 The **"does NOT" list above is the specification** for:
 - the biomarkers sub-agent prompt (`data/prompts/agents/biomarkers_sub_agent.md`), which is the
-  sole guardrail: it instructs the model to show values + the lab's own range and generic
-  education only, and to refer any interpretation to a clinician,
+  sole guardrail: it instructs the model to show values + the lab's own range, generic education, and
+  vetted general (Emerald) knowledge with attribution — never bridging the latter to the user's own
+  value, and referring any interpretation of *their* result to a clinician,
 - the data layer: `lab_status` is stored but **never surfaced** by CRUD/tools, and the single
   result set is enforced by truncate-and-load (`whoopdata/crud/biomarker.py`) — this invariant is
-  tested by `tests/test_biomarker_boundary.py`.
+  tested by `tests/test_biomarker_boundary.py`,
+- the knowledge layer: vetted Emerald markdown is embedded into pgvector
+  (`whoopdata/knowledge/ingest_biomarker_kb.py`) and served read-only as general, source-attributed
+  passages by `get_biomarker_knowledge` (`whoopdata/knowledge/biomarker_kb.py`).
 
 If any line here changes, those implementations must change with it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "3.13.1"
+version = "3.14.0"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -66,6 +66,9 @@ dependencies = [
     "langchain-core>=1.2.0",
     "langchain-text-splitters>=0.3.4",
     "langchain-community>=0.4.0",
+    # Vetted-knowledge RAG (biomarker KB) — pgvector-backed vector store
+    "langchain-postgres>=0.0.12",
+    "pgvector>=0.3.0",
     # OpenAI
     "openai>=1.59.6",
     # Gradio for chat interface

--- a/tests/test_biomarker_kb_ingest.py
+++ b/tests/test_biomarker_kb_ingest.py
@@ -1,0 +1,73 @@
+"""Tests for the biomarker knowledge-base ingestion + graceful fallback.
+
+These cover the parts that don't need a live Postgres:
+- markdown frontmatter parsing and chunk metadata shape (ingestion),
+- the retrieval tool's graceful degradation when the KB is unavailable.
+
+The "no bridging general knowledge to the user's value" contract is a prompt-level
+behaviour (docs/features/BIOMARKER_INTENDED_PURPOSE.md, vetted-knowledge amendment)
+and is best covered by an eval / manual check, not a unit test.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_parse_markdown_splits_frontmatter():
+    from whoopdata.knowledge.ingest_biomarker_kb import parse_markdown
+
+    text = (
+        "---\n"
+        'biomarker: "LDL Cholesterol"\n'
+        "slug: ldl-cholesterol\n"
+        "source_url: https://withemerald.com/knowledge/biomarker/ldl-cholesterol\n"
+        "---\n"
+        "# LDL Cholesterol\n\nBody content.\n"
+    )
+    parsed = parse_markdown(text)
+
+    assert parsed.frontmatter["biomarker"] == "LDL Cholesterol"
+    assert parsed.frontmatter["slug"] == "ldl-cholesterol"
+    assert parsed.body.startswith("# LDL Cholesterol")
+    assert "Body content." in parsed.body
+
+
+def test_chunk_document_carries_attribution_metadata():
+    from whoopdata.knowledge.ingest_biomarker_kb import ParsedDoc, chunk_document
+
+    parsed = ParsedDoc(
+        frontmatter={
+            "biomarker": "LDL Cholesterol",
+            "source": "Emerald",
+            "source_url": "https://withemerald.com/knowledge/biomarker/ldl-cholesterol",
+        },
+        body="# LDL Cholesterol\n\n## What it is\n\nLDL carries cholesterol.\n",
+    )
+    docs = chunk_document(parsed, slug="ldl-cholesterol")
+
+    assert docs, "expected at least one chunk"
+    for doc in docs:
+        assert doc.metadata["biomarker"] == "LDL Cholesterol"
+        assert doc.metadata["source"] == "Emerald"
+        assert doc.metadata["source_url"].endswith("ldl-cholesterol")
+        assert doc.metadata["section"]  # heading captured
+
+
+@pytest.mark.anyio
+async def test_knowledge_tool_graceful_when_kb_unavailable(monkeypatch):
+    """When the KB store can't be built, the tool returns a fallback note."""
+    import whoopdata.knowledge.biomarker_kb as kb
+    from whoopdata.agent.tools import get_biomarker_knowledge_tool
+
+    monkeypatch.setattr(kb, "get_kb_store", lambda *a, **k: None)
+
+    raw = await get_biomarker_knowledge_tool.coroutine(
+        query="what is LDL", biomarker="LDL Cholesterol"
+    )
+    payload = json.loads(raw)
+
+    assert payload["passages"] == []
+    assert "unavailable" in payload["note"].lower()

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "3.12.0"
+__version__ = "3.14.0"

--- a/whoopdata/agent/registry.py
+++ b/whoopdata/agent/registry.py
@@ -198,16 +198,18 @@ AGENT_REGISTRY: dict[str, dict] = {
         "name": "biomarkers",
         "description": (
             "Show the user's blood biomarker results from their most recent lab report: "
-            "the value, the testing lab's own reference range, and generic education about "
-            "what each biomarker is and does. Use this for questions about blood test "
-            "results, biomarkers, or lab values. This specialist only displays values and "
-            "generic education — it does NOT interpret results, say whether a value is "
-            "high/low, diagnose, or give medical advice."
+            "the value, the testing lab's own reference range, and education about what "
+            "each biomarker is and does — including vetted, source-attributed general "
+            "knowledge from Emerald's knowledge base. Use this for questions about blood "
+            "test results, biomarkers, or lab values. This specialist displays values and "
+            "general education only — it does NOT interpret the user's own results, say "
+            "whether their value is high/low, diagnose, or give medical advice."
         ),
         "system_prompt": _load_prompt("biomarkers_sub_agent.md"),
         "tools": [
             "get_biomarker_results",
             "get_biomarker_education",
+            "get_biomarker_knowledge",
         ],
     },
 }

--- a/whoopdata/agent/settings.py
+++ b/whoopdata/agent/settings.py
@@ -33,6 +33,17 @@ AGENT_POSTGRES_URL = os.getenv("AGENT_POSTGRES_URL")
 AGENT_PERSISTENCE_AUTO_SETUP = (
     os.getenv("AGENT_PERSISTENCE_AUTO_SETUP", "true").strip().lower() == "true"
 )
+
+# Biomarker knowledge base (vetted Emerald content, pgvector-backed RAG).
+# Defaults to the same Postgres instance used for agent persistence. When this
+# is unset / Postgres is down, the retrieval tool degrades gracefully and the
+# agent falls back to the DB-backed get_biomarker_education glossary.
+BIOMARKER_KB_POSTGRES_URL = os.getenv("BIOMARKER_KB_POSTGRES_URL", AGENT_POSTGRES_URL)
+BIOMARKER_KB_COLLECTION = os.getenv("BIOMARKER_KB_COLLECTION", "emerald_biomarker_kb")
+BIOMARKER_KB_EMBEDDING_MODEL = os.getenv(
+    "BIOMARKER_KB_EMBEDDING_MODEL", "text-embedding-3-small"
+)
+BIOMARKER_KB_TOP_K = int(os.getenv("BIOMARKER_KB_TOP_K", "4"))
 # Proactive coach configuration (settings-only single source of truth)
 # Used by: whoopdata/services/proactive_coach.py
 PROACTIVE_COACH_ENABLED = True

--- a/whoopdata/agent/settings.py
+++ b/whoopdata/agent/settings.py
@@ -40,9 +40,7 @@ AGENT_PERSISTENCE_AUTO_SETUP = (
 # agent falls back to the DB-backed get_biomarker_education glossary.
 BIOMARKER_KB_POSTGRES_URL = os.getenv("BIOMARKER_KB_POSTGRES_URL", AGENT_POSTGRES_URL)
 BIOMARKER_KB_COLLECTION = os.getenv("BIOMARKER_KB_COLLECTION", "emerald_biomarker_kb")
-BIOMARKER_KB_EMBEDDING_MODEL = os.getenv(
-    "BIOMARKER_KB_EMBEDDING_MODEL", "text-embedding-3-small"
-)
+BIOMARKER_KB_EMBEDDING_MODEL = os.getenv("BIOMARKER_KB_EMBEDDING_MODEL", "text-embedding-3-small")
 BIOMARKER_KB_TOP_K = int(os.getenv("BIOMARKER_KB_TOP_K", "4"))
 # Proactive coach configuration (settings-only single source of truth)
 # Used by: whoopdata/services/proactive_coach.py
@@ -148,6 +146,8 @@ def get_supervisor_llm_config() -> dict[str, Any]:
 def get_specialist_llm_config(name: str) -> dict[str, Any]:
     """Return model settings for a specialist, falling back to specialist_default."""
     return dict(LLM_CONFIG.get(name, LLM_CONFIG["specialist_default"]))
+
+
 SPECIALIST_MODEL = "openai:gpt-4o-mini"
 
 # Voice transcription (Whisper)
@@ -161,4 +161,3 @@ TTS_INSTRUCTIONS = (
     "like a personal trainer who's also a data scientist with the whit and Charm of Hannah Fry "
     "Keep it conversational and natural, not robotic."
 )
-

--- a/whoopdata/agent/tools.py
+++ b/whoopdata/agent/tools.py
@@ -1,5 +1,6 @@
 """Agent tools for health data retrieval."""
 
+import asyncio
 import httpx
 import json
 from langchain_core.tools import tool
@@ -1152,6 +1153,77 @@ async def get_biomarker_education_tool(biomarker: str) -> str:
         return f"Error retrieving biomarker education: {str(e)}"
 
 
+@tool(
+    "get_biomarker_knowledge",
+    description=(
+        "Look up vetted, source-attributed general knowledge about a biomarker from "
+        "Emerald's knowledge base, including what elevated or low levels generally "
+        "indicate. This is GENERAL reference material, NOT about the user's own value. "
+        "Use it to enrich education; never connect what is returned to the user's "
+        "specific result. Returns relevant passages with their Emerald source URL."
+    ),
+)
+async def get_biomarker_knowledge_tool(query: str, biomarker: str = None) -> str:
+    """Retrieve vetted general knowledge passages about a biomarker.
+
+    Args:
+        query: What to look up, e.g. "what does elevated LDL indicate".
+        biomarker: Optional biomarker name to scope the search, e.g. "LDL Cholesterol".
+
+    Returns:
+        JSON string of source-attributed passages, or a note when the knowledge
+        base is unavailable (so the caller falls back to get_biomarker_education).
+    """
+    try:
+        from whoopdata.knowledge.biomarker_kb import get_kb_store
+
+        store = get_kb_store()
+        if store is None:
+            return json.dumps({
+                "passages": [],
+                "note": (
+                    "Vetted knowledge base is unavailable; use get_biomarker_education "
+                    "for generic education instead."
+                ),
+            })
+
+        k = settings.BIOMARKER_KB_TOP_K
+
+        # PGVector.similarity_search is sync/blocking; offload to a thread so this
+        # async tool doesn't stall the event loop. Filter uses the documented
+        # operator syntax ({"field": {"$eq": value}}).
+        def _search(flt):
+            return store.similarity_search(query, k=k, filter=flt)
+
+        hits = []
+        if biomarker:
+            hits = await asyncio.to_thread(_search, {"biomarker": {"$eq": biomarker}})
+        if not hits:
+            # No biomarker given, or the scoped filter matched nothing — fall back
+            # to an unfiltered semantic search.
+            hits = await asyncio.to_thread(_search, None)
+
+        if not hits:
+            return json.dumps({
+                "passages": [],
+                "note": "No vetted knowledge matched this query.",
+            })
+
+        passages = [
+            {
+                "content": doc.page_content,
+                "biomarker": doc.metadata.get("biomarker"),
+                "section": doc.metadata.get("section"),
+                "source": doc.metadata.get("source", "Emerald"),
+                "source_url": doc.metadata.get("source_url"),
+            }
+            for doc in hits
+        ]
+        return json.dumps({"passages": passages}, indent=2, default=str)
+    except Exception as e:
+        return f"Error retrieving biomarker knowledge: {str(e)}"
+
+
 TOOLS_BY_NAME: dict[str, object] = {}
 
 
@@ -1200,6 +1272,7 @@ AVAILABLE_TOOLS = [
     # Biomarker Tools (Phase 0 prototype)
     get_biomarker_results_tool,
     get_biomarker_education_tool,
+    get_biomarker_knowledge_tool,
 ]
 
 # Populate name-based lookup

--- a/whoopdata/agent/tools.py
+++ b/whoopdata/agent/tools.py
@@ -1072,10 +1072,12 @@ async def get_biomarker_results_tool(category: str = None) -> str:
             db.close()
 
         if not all_rows:
-            return json.dumps({
-                "results": [],
-                "note": "No biomarker report has been loaded for this user.",
-            })
+            return json.dumps(
+                {
+                    "results": [],
+                    "note": "No biomarker report has been loaded for this user.",
+                }
+            )
 
         rows = all_rows
         note = None
@@ -1084,7 +1086,8 @@ async def get_biomarker_results_tool(category: str = None) -> str:
             # Lenient match on body-system category OR biomarker name, so the
             # caller never has to guess the exact category string.
             filtered = [
-                r for r in all_rows
+                r
+                for r in all_rows
                 if term in (r.get("category") or "").lower()
                 or term in (r.get("source_biomarker_name") or "").lower()
             ]
@@ -1100,7 +1103,9 @@ async def get_biomarker_results_tool(category: str = None) -> str:
 
         payload = {
             "report": {
-                "taken_on": report.taken_on.date().isoformat() if report and report.taken_on else None,
+                "taken_on": (
+                    report.taken_on.date().isoformat() if report and report.taken_on else None
+                ),
                 "lab_provider": report.lab_provider if report else None,
             },
             "results": rows,
@@ -1140,15 +1145,20 @@ async def get_biomarker_education_tool(biomarker: str) -> str:
             db.close()
 
         if entry is None:
-            return json.dumps({
-                "biomarker": biomarker,
-                "note": "No generic education is available for this biomarker.",
-            })
-        return json.dumps({
-            "biomarker": entry.source_biomarker_name,
-            "what_it_is": entry.what_it_is,
-            "physiological_function": entry.physiological_function,
-        }, indent=2)
+            return json.dumps(
+                {
+                    "biomarker": biomarker,
+                    "note": "No generic education is available for this biomarker.",
+                }
+            )
+        return json.dumps(
+            {
+                "biomarker": entry.source_biomarker_name,
+                "what_it_is": entry.what_it_is,
+                "physiological_function": entry.physiological_function,
+            },
+            indent=2,
+        )
     except Exception as e:
         return f"Error retrieving biomarker education: {str(e)}"
 
@@ -1179,13 +1189,15 @@ async def get_biomarker_knowledge_tool(query: str, biomarker: str = None) -> str
 
         store = get_kb_store()
         if store is None:
-            return json.dumps({
-                "passages": [],
-                "note": (
-                    "Vetted knowledge base is unavailable; use get_biomarker_education "
-                    "for generic education instead."
-                ),
-            })
+            return json.dumps(
+                {
+                    "passages": [],
+                    "note": (
+                        "Vetted knowledge base is unavailable; use get_biomarker_education "
+                        "for generic education instead."
+                    ),
+                }
+            )
 
         k = settings.BIOMARKER_KB_TOP_K
 
@@ -1204,10 +1216,12 @@ async def get_biomarker_knowledge_tool(query: str, biomarker: str = None) -> str
             hits = await asyncio.to_thread(_search, None)
 
         if not hits:
-            return json.dumps({
-                "passages": [],
-                "note": "No vetted knowledge matched this query.",
-            })
+            return json.dumps(
+                {
+                    "passages": [],
+                    "note": "No vetted knowledge matched this query.",
+                }
+            )
 
         passages = [
             {

--- a/whoopdata/knowledge/__init__.py
+++ b/whoopdata/knowledge/__init__.py
@@ -1,0 +1,1 @@
+"""Vetted-knowledge RAG for the biomarker sub-agent (Emerald content)."""

--- a/whoopdata/knowledge/biomarker_kb.py
+++ b/whoopdata/knowledge/biomarker_kb.py
@@ -1,0 +1,70 @@
+"""Shared pgvector store for the biomarker knowledge base (Emerald RAG).
+
+This is the single construction point used by both the ingestion script
+(``ingest_biomarker_kb``) and the runtime retrieval tool
+(``get_biomarker_knowledge`` in ``whoopdata.agent.tools``).
+
+Design notes / boundary:
+- The KB is a **general, non-personalised, source-attributed library** of vetted
+  Emerald content. It is not applied to an individual's data. See
+  ``docs/features/BIOMARKER_INTENDED_PURPOSE.md``.
+- Construction is best-effort: if Postgres is unavailable or the dependency is
+  missing, ``get_kb_store`` returns ``None`` so callers can degrade gracefully
+  (the agent falls back to the DB-backed ``get_biomarker_education`` glossary).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from whoopdata.agent import settings
+
+
+def _normalise_url(url: str) -> str:
+    """Coerce a libpq URL to the psycopg3 SQLAlchemy driver form.
+
+    ``AGENT_POSTGRES_URL`` is typically ``postgresql://...?sslmode=disable``;
+    langchain-postgres builds a SQLAlchemy engine and needs the explicit
+    ``postgresql+psycopg://`` driver. ``sslmode`` is left intact (psycopg3
+    accepts it as a connection keyword).
+    """
+    if url.startswith("postgresql+"):
+        return url
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url[len("postgresql://") :]
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url[len("postgres://") :]
+    return url
+
+
+def get_embeddings() -> Any:
+    """Return the OpenAI embeddings client used for the KB."""
+    from langchain_openai import OpenAIEmbeddings
+
+    return OpenAIEmbeddings(model=settings.BIOMARKER_KB_EMBEDDING_MODEL)
+
+
+def get_kb_store(create_extension: bool = False) -> Optional[Any]:
+    """Return the PGVector store for the biomarker KB, or ``None`` if unavailable.
+
+    Args:
+        create_extension: When True (ingestion path), ensure the pgvector
+            extension and collection tables exist. The runtime tool leaves this
+            False to avoid DDL on the hot path.
+    """
+    url = settings.BIOMARKER_KB_POSTGRES_URL
+    if not url:
+        return None
+    try:
+        from langchain_postgres import PGVector
+
+        return PGVector(
+            embeddings=get_embeddings(),
+            collection_name=settings.BIOMARKER_KB_COLLECTION,
+            connection=_normalise_url(url),
+            use_jsonb=True,
+            create_extension=create_extension,
+        )
+    except Exception:
+        # Missing dependency, Postgres down, or pgvector not installed server-side.
+        return None

--- a/whoopdata/knowledge/ingest_biomarker_kb.py
+++ b/whoopdata/knowledge/ingest_biomarker_kb.py
@@ -1,0 +1,173 @@
+"""Ingest vetted Emerald biomarker markdown into the pgvector knowledge base.
+
+Run with::
+
+    python -m whoopdata.knowledge.ingest_biomarker_kb [--dir data/knowledge/biomarkers]
+
+Input contract — one markdown file per biomarker with YAML frontmatter::
+
+    ---
+    biomarker: "LDL Cholesterol"
+    slug: ldl-cholesterol
+    source: Emerald
+    source_url: https://withemerald.com/knowledge/biomarker/ldl-cholesterol
+    retrieved_at: 2026-06-20
+    ---
+    # LDL Cholesterol
+    ...vetted body content...
+
+Idempotent: each chunk is written with a deterministic id (``<slug>-<n>``), so
+re-running upserts rather than duplicating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from langchain_core.documents import Document
+from langchain_text_splitters import (
+    MarkdownHeaderTextSplitter,
+    RecursiveCharacterTextSplitter,
+)
+
+from whoopdata.knowledge.biomarker_kb import get_kb_store
+
+DEFAULT_DIR = Path("data/knowledge/biomarkers")
+
+_HEADERS_TO_SPLIT_ON = [("#", "h1"), ("##", "h2"), ("###", "h3")]
+
+
+@dataclass
+class ParsedDoc:
+    frontmatter: dict
+    body: str
+
+
+def parse_markdown(text: str) -> ParsedDoc:
+    """Split YAML frontmatter from the markdown body.
+
+    Tolerant of frontmatter that isn't strictly valid YAML — some scraped values
+    contain unquoted colons (e.g. ``normal_range: Male: 40-54% Female: 37-47%``),
+    which breaks ``yaml.safe_load``. On any parse error we fall back to a simple
+    split-on-first-colon parse so the file is still ingested.
+    """
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            raw_fm = parts[1]
+            try:
+                fm = yaml.safe_load(raw_fm) or {}
+                if not isinstance(fm, dict):
+                    raise ValueError("frontmatter is not a mapping")
+            except Exception:
+                fm = _parse_frontmatter_lenient(raw_fm)
+            return ParsedDoc(frontmatter=fm, body=parts[2].strip())
+    return ParsedDoc(frontmatter={}, body=text.strip())
+
+
+def _parse_frontmatter_lenient(raw: str) -> dict:
+    """Parse ``key: value`` lines, tolerating colons inside the value."""
+    out: dict = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip().strip('"').strip("'")
+    return out
+
+
+def chunk_document(parsed: ParsedDoc, slug: str, category: str = None) -> list[Document]:
+    """Chunk a parsed biomarker doc, preserving section headings in metadata.
+
+    Tolerant of two frontmatter dialects: the Emerald scrape (``title`` / ``source`` /
+    ``health_area``) and the earlier hand-authored form (``biomarker`` / ``source_url``).
+    """
+    fm = parsed.frontmatter
+    biomarker = fm.get("title") or fm.get("biomarker") or slug
+    base_meta = {
+        "biomarker": biomarker,
+        "slug": slug,
+        "category": fm.get("health_area") or fm.get("category") or category,
+        "type": fm.get("type"),
+        "normal_range": fm.get("normal_range"),
+        "source": "Emerald",
+        # Emerald scrape stores the page URL in `source`; older form used `source_url`.
+        "source_url": fm.get("source_url") or fm.get("source"),
+    }
+    base_meta = {k: v for k, v in base_meta.items() if v is not None}
+
+    header_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=_HEADERS_TO_SPLIT_ON, strip_headers=False
+    )
+    sections = header_splitter.split_text(parsed.body)
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=150)
+
+    docs: list[Document] = []
+    for section in sections:
+        section_name = (
+            section.metadata.get("h3")
+            or section.metadata.get("h2")
+            or section.metadata.get("h1")
+            or biomarker
+        )
+        for piece in text_splitter.split_text(section.page_content):
+            meta = dict(base_meta)
+            meta["section"] = section_name
+            docs.append(Document(page_content=piece, metadata=meta))
+    return docs
+
+
+def ingest(directory: Path) -> int:
+    """Embed and upsert every markdown file in ``directory``. Returns chunk count."""
+    _skip = {"readme.md", "index.md"}
+    files = [p for p in sorted(directory.rglob("*.md")) if p.name.lower() not in _skip]
+    if not files:
+        print(f"No markdown files found in {directory}", file=sys.stderr)
+        return 0
+
+    store = get_kb_store(create_extension=True)
+    if store is None:
+        print(
+            "Knowledge base unavailable (Postgres/pgvector not reachable). "
+            "Is the postgres container up and BIOMARKER_KB_POSTGRES_URL set?",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total = 0
+    for path in files:
+        parsed = parse_markdown(path.read_text(encoding="utf-8"))
+        slug = parsed.frontmatter.get("slug") or path.stem
+        # Category folder (e.g. "heart-health") when the corpus is nested.
+        category = path.parent.name if path.parent != directory else None
+        docs = chunk_document(parsed, slug, category=category)
+        if not docs:
+            print(f"  {path.name}: no content, skipped")
+            continue
+        # Stable id keyed by relative path so re-runs upsert and slugs can't collide
+        # across categories.
+        key = path.relative_to(directory).with_suffix("").as_posix()
+        ids = [f"{key}-{i}" for i in range(len(docs))]
+        store.add_documents(docs, ids=ids)
+        total += len(docs)
+        print(f"  {path.relative_to(directory)}: {len(docs)} chunks")
+
+    print(f"Ingested {total} chunks from {len(files)} files.")
+    return total
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", type=Path, default=DEFAULT_DIR)
+    args = parser.parse_args(argv)
+    ingest(args.dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Grounds the **biomarkers** specialist in vetted Emerald knowledge via a pgvector RAG layer, so it can give source-attributed general information about a biomarker (including what high/low levels *generally* mean) instead of thin, model-sourced education — while keeping the existing safety boundary intact.

## What's included

- **New tool `get_biomarker_knowledge`** — semantic search over Emerald's knowledge base (~119 pages / 1,548 chunks, `text-embedding-3-small`), returning source-attributed passages. Scoped to the biomarker specialist only (not the supervisor), so the no-bridging guardrail stays in one prompt.
- **`whoopdata/knowledge/`** — shared `PGVector` store builder with graceful degradation (falls back to the `get_biomarker_education` glossary when Postgres/pgvector is unavailable) + an idempotent `python -m` ingestion script (recursive walk, header-aware chunking, lenient YAML for colon-bearing frontmatter).
- **Prompt hardening** — `get_biomarker_knowledge` is now the primary education source, and Emerald attribution is only allowed for content a tool actually returned this turn (fixes a bug found in testing where the agent fabricated "Per Emerald" from model memory when the glossary was empty).
- **Infra** — `docker-compose` Postgres → `pgvector/pgvector:pg16` (one instance serves agent persistence + the KB); deps add `langchain-postgres` + `pgvector`.
- **Docs** — `BIOMARKER_INTENDED_PURPOSE.md` vetted-knowledge amendment: the KB is a general, source-attributed library (not a device function); the medical-purpose risk is *juxtaposition*, controlled by the serving contract rather than by stripping the corpus.

## Safety boundary (unchanged in spirit)

General knowledge is served **stand-alone** and never bridged to the user's own value. Verified live via LangSmith traces: "Is my glucose high?" returns value + lab range + general Emerald knowledge but **no high/low verdict**; an out-of-corpus marker (selenium) cleanly reports "no Emerald entry" with no fabrication.

## Verification

- `tests/test_biomarker_kb_ingest.py` + existing `tests/test_biomarker_boundary.py` pass.
- End-to-end against the running stack: ingestion (idempotent), retrieval, and `get_biomarker_knowledge` tool-call confirmed firing in LangSmith traces.

## Operator note

The scraped Emerald corpus is **gitignored** (reproducible via the ingestion script). Existing stock-`postgres:16` persistence containers must be recreated on the pgvector image (`pg_dump` → recreate → `pg_restore`) to enable the KB; until then the tool degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)