### PR TITLE
feat(personality): swap Bob Mortimer for Sterling Archer (v3.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the WHOOP Data Platform will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.14.1] - 2026-06-22
+
+### Changed
+- Supervisor coach personality (`data/prompts/agents/supervisor.md`): swapped Bob Mortimer for fictional secret agent Sterling Archer. "Mortimer's absurdity" becomes "Archer's swagger" (cocky one-liners, sardonic quips, the odd "danger zone" bravado); the example-tone label is updated to match. Tone tweak only -- no behavioural or routing change.
+
 ## [3.14.0] - 2026-06-21
 
 ### Added

--- a/data/prompts/agents/supervisor.md
+++ b/data/prompts/agents/supervisor.md
@@ -2,11 +2,11 @@
 
 You are a sharp, evidence-based health data coach with personality.
 
-You're the lovechild of Hannah Fry, David Goggins, Joe Rogan, Bob Mortimer, and Andrew Huberman:
+You're the lovechild of Hannah Fry, David Goggins, Joe Rogan, Sterling Archer, and Andrew Huberman:
 - **Hannah Fry's precision** — You break down the maths, explain the patterns, make data fascinating
 - **Goggins' intensity** — No excuses, no hand-holding, call out the truth even when it stings
 - **Rogan's curiosity** — "That's interesting..." You connect dots, ask follow-ups, explore the why
-- **Mortimer's absurdity** — A well-placed joke, a weird analogy, keep it human and fun
+- **Archer's swagger** — Cocky one-liners, a sardonic quip, the odd "danger zone" bravado, keep it human and fun
 - **Huberman's protocols** — Science-backed, actionable, specific about timing and dosage
 
 Brief, analytical, entertaining. Data-driven but never boring.
@@ -150,7 +150,7 @@ If the current conversation already contains a previously uploaded image, do not
 *Interesting pattern:*
 > This is fascinating — your best recovery scores all happen after tennis, not running. Your body's telling you something. Tennis gives you HIIT-style intervals without the sustained pounding. Your HRV loves it.
 
-*Odd analogy (Bob Mortimer energy):*
+*Odd analogy (Sterling Archer energy):*
 > Your protein intake's like trying to build a house with half the bricks. You can do it, technically, but it'll be a shit house and take twice as long. Get more bricks.
 
 **Bad (robotic, boring, forgettable):**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["whoopdata"]
 
 [project]
 name = "whoop-data"
-version = "3.14.0"
+version = "3.14.1"
 description = "WHOOP and Withings Health Data Integration Platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/whoopdata/__version__.py
+++ b/whoopdata/__version__.py
@@ -1,3 +1,3 @@
 """Version information for the WHOOP Data Platform."""
 
-__version__ = "3.14.0"
+__version__ = "3.14.1"


### PR DESCRIPTION
## Summary

Swaps **Bob Mortimer** for fictional secret agent **Sterling Archer** in the supervisor coach personality (`data/prompts/agents/supervisor.md`).

- The "lovechild of…" persona list now names Sterling Archer.
- *Mortimer's absurdity* → **Archer's swagger** — cocky one-liners, sardonic quips, the odd "danger zone" bravado.
- The example-tone label (`… energy`) is updated to match.

Tone tweak only — no behavioural, routing, or safety change. Verified live after a `services` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)